### PR TITLE
Organizing Use Case and Value Scenarios

### DIFF
--- a/value-scenarios/contributor-scenarios/Dell/README.md
+++ b/value-scenarios/contributor-scenarios/Dell/README.md
@@ -89,3 +89,8 @@ Affected_Products
 
 ```
 
+A few examples of Dell End of Security Support documents which contain subset of the data that would need to be supported by a machine-readable format.
+- https://www.dell.com/support/kbdoc/en-us/000224135/cloudlink-security-support-policy-and-security-update-release-schedule-for-supported-versions
+- https://www.dell.com/support/kbdoc/en-ca/000222799/security-support-policy-for-dell-docking-stations-with-an-integrated-ethernet-port
+- https://www.dell.com/support/kbdoc/en-ca/000128563/end-of-life-end-of-support-policy-for-dell-data-security
+ 

--- a/value-scenarios/contributor-scenarios/Dell/README.md
+++ b/value-scenarios/contributor-scenarios/Dell/README.md
@@ -1,0 +1,91 @@
+# Dell's Use Case and Value Scenarios
+- Contributor: Langley, Dell
+- Originally discussed in [Issue #14](https://github.com/oasis-tcs/openeox/issues/14)
+
+
+Companies including our own may speak in terms of End of Sale, End of Standard Support, End of Security Support/Life, End of Life, End of Service Life.  These terms might not match the use case of other vendors.
+ 
+Because of this, a flexible schema is anticipated as being needed.
+ 
+Below is a proposed standalone & hopefully universal schema that addresses some known use cases.
+ 
+```
+{
+Vendor, 
+    // required
+    // Name of vendor 
+    // arbitrary text
+Email,
+    // required
+    // contact address for vendor
+    // email formatted text
+Website,
+    // required
+    // Primary Vendor URL 
+    // URL text
+ID, 
+    // required
+    // with the Notification Date, will form a primary key
+    // incremental ID starting with 001
+Label, 
+    // required
+    // label the vendor uses for the type of communication. 
+    // e.g., "End of Sale", "End of Life", "End of Support", "End of Security Support"
+Description, 
+    // optional
+    // describe what this means to the end user and provide other notes as needed
+    // arbitrary text field
+Notification_Date, 
+    // required
+    // date this is published.  
+    // ISO 8601 format
+Effective_Date, 
+    // required
+    // date when the policy comes into effect.  
+    // ISO 8601 format
+End_Date, 
+    // optional
+    // date when policy is no longer effective (e.g., partial to none for support). 
+    // ISO 8601 format
+Category, 
+    // required
+    // category of EoX to allow cross-vendor grouping of different "Label" values 
+    // One of ["Sales"|"Support"|"Security Support"|"Other"]
+Support_Term, 
+    // optional
+    // alternative to End_date if the term is based on date of sale (e.g., 3 years)
+    // arbitrary text
+Support_Coverage, 
+    // required (if support);
+    // Extent of support; 
+    // One of ["None"|"Partial"|"Full"]
+Policy_URLs, 
+    // optional
+    // delimited list of links to where the formal policies are found
+    // Arbitrary vendor URLs 
+Previous_Reference, 
+    // optional
+    // list of previous record(s) this replaces
+    // Notification_Date+ID 
+Affected_Products 
+    // required
+    // min. 1
+    // record structure
+    {
+    Product_Name, 
+        // required
+        // name of the product
+        // arbitrary vendor product name
+    Product_Version, 
+        // required
+        // string of one or more versions
+        // arbitrary text, or "All"
+    Product_URLs 
+        // optional; 
+        // delimited list of product pages and other relevant info
+        // arbitrary vendor URLs for specific products
+    }
+}
+
+```
+

--- a/value-scenarios/contributor-scenarios/README.md
+++ b/value-scenarios/contributor-scenarios/README.md
@@ -1,2 +1,30 @@
-# Contributor Scenarios
-blah blah fill in
+# OpenEoX Contributor Use Case and Value Scenarios
+
+This section is dedicated to documenting different initial use cases and value scenarios for the adoption and implementation of OpenEoX across various organizations and industries.
+
+## Overview
+
+OpenEoX aims to provide a unified framework, OpenEoX enables organizations, both vendors and open-source maintainers, to share, manage, and consume lifecycle data in a transparent and efficient manner.
+
+This **Contributor Use Case and Value Scenarios** section is designed to illustrate the diverse applications of OpenEoX, highlighting how different organizations can benefit from the framework.
+
+## Folder Structure
+
+Each folder within this section corresponds to a specific use case or value scenario provided by industry stakeholders, vendors, or community contributors. The structure is as follows:
+
+```
+/contributor-scenarios
+  ├── /BSI
+  ├── /Dell
+  ├── /Oracle
+  ├── /Redhat
+  └── /others..
+```
+
+We encourage contributions from anyone with a relevant use case or scenario that demonstrates the value of OpenEoX in real-world applications. To add your use case:
+
+1. Fork the repository.
+2. Create a folder under `/contributor-scenarios` that fits your scenario (e.g., `/contributor-scenarios/your-organization`).
+3. Document your use case in a `README.md` file within your folder.
+4. Submit a pull request.
+

--- a/value-scenarios/contributor-scenarios/Redhat/README.md
+++ b/value-scenarios/contributor-scenarios/Redhat/README.md
@@ -1,0 +1,3 @@
+# Redhat's Use Case and Value Scenarios
+- Contributor: Redhat
+- This section will be updated by Redhat later.

--- a/value-scenarios/general-scenarios/README.md
+++ b/value-scenarios/general-scenarios/README.md
@@ -1,2 +1,4 @@
-# General Scenarios
-fill in blah blah
+# OpenEoX Contributor Use Case and Value Scenarios
+This section is dedicated to documenting the general (not organization-specific) use cases and value scenarios for the adoption and implementation of OpenEoX.
+
+Please contribute your use case or scenario that demonstrates the value of OpenEoX under the `contributor-scenarios` folder.


### PR DESCRIPTION
Fixes #39

Added README.md for Use Case and Value Scenarios

- Created a README.md file to explain the structure and purpose of the /use-cases folder
- Detailed instructions on how to contribute use cases for vendors, open-source maintainers, government and any other organizations.
- Provided guidelines for documenting use cases, including description, challenges, value proposition, and outcomes.
- Added Oracle, Dell, and placeholder for Redhat