### PR TITLE
Adding the End of Security Support Definition

### DIFF
--- a/definitions-taxonomy/End-of-Security-Support.md
+++ b/definitions-taxonomy/End-of-Security-Support.md
@@ -1,3 +1,4 @@
-# End of Security Support (EoSSec)
-End of Security Support (EoSSec) indicates the last day when the vendor has committed to providing security remediations for the particular product (or the product version/release).
+# End-of-Security-Support (EoSSec) Definition
+
+End-of-Security-Support (EoSSec) indicates the last day when the vendor has committed to providing security remediations for the particular product (or the product version/release).
 

--- a/definitions-taxonomy/End-of-Security-Support.md
+++ b/definitions-taxonomy/End-of-Security-Support.md
@@ -1,0 +1,3 @@
+# End of Security Support (EoSS)
+End of Security Support (EoSS) indicates the last day when the vendor has committed to providing security remediations for the particular product (or the product version/release).
+

--- a/definitions-taxonomy/End-of-Security-Support.md
+++ b/definitions-taxonomy/End-of-Security-Support.md
@@ -1,3 +1,3 @@
-# End of Security Support (EoSS)
-End of Security Support (EoSS) indicates the last day when the vendor has committed to providing security remediations for the particular product (or the product version/release).
+# End of Security Support (EoSSec)
+End of Security Support (EoSSec) indicates the last day when the vendor has committed to providing security remediations for the particular product (or the product version/release).
 


### PR DESCRIPTION
Fixes #32 

Adding the End of Security Support Definition as discussed on 2025-04-09 and documented [here](https://github.com/oasis-tcs/openeox/issues/32#:~:text=Draft%20Definition%3A-,End%20of%20Security%20Support%20(EoSS),security%20remediations%20for%20the%20particular%20product%20(or%20the%20product%20version/release).,-As%20an%20informative).