### PR TITLE
Adding Product Definition

### DIFF
--- a/definitions-taxonomy/Product.md
+++ b/definitions-taxonomy/Product.md
@@ -1,0 +1,3 @@
+# Product
+
+Product is any deliverable (e.g. software, hardware, specification, services, etc.) which can be referred to with a name. This applies regardless of the origin, the license model, or the mode of distribution of the deliverable.

--- a/definitions-taxonomy/Product.md
+++ b/definitions-taxonomy/Product.md
@@ -1,3 +1,3 @@
 # Product
 
-Product is any deliverable (e.g. software, hardware, specification, services, etc.) which can be referred to with a name. This applies regardless of the origin, the license model, or the mode of distribution of the deliverable.
+Product is any deliverable (e.g. software, hardware, specification, or services) which can be referred to with a name. This applies regardless of the origin, the license model, or the mode of distribution of the deliverable.

--- a/definitions-taxonomy/Product.md
+++ b/definitions-taxonomy/Product.md
@@ -1,3 +1,3 @@
 # Product
 
-Product is any deliverable (e.g. software, hardware, specification, or services) which can be referred to with a name. This applies regardless of the origin, the license model, or the mode of distribution of the deliverable.
+Product is any deliverable (e.g. software, hardware, specification, or service) which can be referred to with a name. This applies regardless of the origin, the license model, or the mode of distribution of the deliverable.


### PR DESCRIPTION
This pull request adds the `definitions-taxonomy/Product.md` file. It adds a definition for the term "Product."

* [`definitions-taxonomy/Product.md`](diffhunk://#diff-3c12bd9c54e915d10a3cf304907603334aa136596f19d45a307b333535fd8c97R1-R3): Added a definition for "Product" describing it as any deliverable that can be referred to with a name, regardless of its origin, license model, or distribution mode.