### PR TITLE
docs: add June 2025 meeting minutes

### DIFF
--- a/meeting-minutes/2025/2025-06-18.md
+++ b/meeting-minutes/2025/2025-06-18.md
@@ -30,7 +30,7 @@ Quorum requires participation of 8 or more of the 14 voting members (including t
 | Sergii     | Demianchuk  | Cisco Systems                                               | Member        | No      |
 | Shridhar   | Chari       | Cisco Systems                                               | Voting Member | No      |
 | Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member | Yes     |
-| Stefan     | Arntzen     | Huawei Technologies Co., Ltd.                               | Voting Member | No      |
+| Stefan     | Arntzen     | Huawei Technologies Co., Ltd.                               | Member | No      |
 | Stefan     | Hagen       | Individual                                                  | Secretary     | Yes     |
 | Thomas     | Proell      | Siemens                                                     | Member        | No      |
 | Thomas     | Schaffer    | Cisco Systems                                               | Voting Member | No      |

--- a/meeting-minutes/2025/2025-06-18.md
+++ b/meeting-minutes/2025/2025-06-18.md
@@ -1,0 +1,145 @@
+# 1. Opening Activities
+
+## 1.1 Opening comments (Co-Chair)
+
+- Justin & Omar open the meeting.
+
+## 1.2 Introduction of participants/roll call (Co-Chair)
+
+Quorum requires participation of 8 or more of the 14 voting members (including the officers).
+
+| First Name | Last Name   | Company                                                     | Role(s)       | Present |
+|:-----------|:------------|:------------------------------------------------------------|:--------------|:--------|
+| Adrian     | Diglio      | Microsoft                                                   | Member        | No      |
+| Art        | Middlekauff | Flexera                                                     | Voting Member | No      |
+| David      | Kemp        | National Security Agency                                    | Member        | No      |
+| Denny      | Page        | Individual                                                  | Voting Member | No      |
+| Feng       | Cao         | Oracle                                                      | Voting Member | Yes     |
+| Harin      | Sarda       | Cisco Systems                                               | Voting Member | Yes     |
+| Jautau     | White       | Microsoft                                                   | Voting Member | Yes     |
+| Jeremy     | Rickard     | Microsoft                                                   | Member        | No      |
+| Justin     | Murphy      | DHS Cybersecurity and Infrastructure Security Agency (CISA) | Co-Chair      | Yes     |
+| Kris       | Vandecruys  | Cisco Systems                                               | Member        | No      |
+| Kunal      | Modasiya    | Qualys, Inc.                                                | Member        | No      |
+| Langley    | Rock        | Dell                                                        | Voting Member | Yes     |
+| Martin     | Prpic       | Red Hat                                                     | Member        | No      |
+| Omar       | Santos      | Cisco Systems                                               | Co-Chair      | Yes     |
+| Pablo      | Quiroga     | Qualys, Inc.                                                | Member        | No      |
+| Peter      | Gephardt    | IBM                                                         | Member        | No      |
+| Przemyslaw | Roguski     | Red Hat                                                     | Voting Member | No      |
+| Sergii     | Demianchuk  | Cisco Systems                                               | Member        | No      |
+| Shridhar   | Chari       | Cisco Systems                                               | Voting Member | No      |
+| Sonny      | van Lingen  | Huawei Technologies Co., Ltd.                               | Voting Member | Yes     |
+| Stefan     | Arntzen     | Huawei Technologies Co., Ltd.                               | Voting Member | No      |
+| Stefan     | Hagen       | Individual                                                  | Secretary     | Yes     |
+| Thomas     | Proell      | Siemens                                                     | Member        | No      |
+| Thomas     | Schaffer    | Cisco Systems                                               | Voting Member | No      |
+| Thomas     | Schmidt     | Federal Office for Information Security (BSI) Germany       | Voting Member | Yes     |
+| Tobias     | Limmer      | Siemens                                                     | Member        | No      |
+
+Quorum was reached (8 voting members present).
+
+## 1.3 Procedures for this meeting (Moderator)
+
+## 1.4 Approval of agenda
+
+- Roll Call  
+- Updates
+- Approval of previous meeting minutes (motions carried out per e-mail motions)  
+- Review of actions
+- Review of outstanding issues and pull requests marked for TC discussion: [https://github.com/oasis-tcs/openeox](https://github.com/oasis-tcs/openeox)  
+- Next steps  
+
+## 1.5 Approval of previous minutes (Moderator)
+
+- Motions will be set via mailing list.
+
+## 1.6 Review of action items and resolutions (Secretary Stefan)
+
+## 1.7 Identification of TC voting members (Secretary)
+
+### 1.7.1 Prospective voting members attending their first meeting
+
+### 1.7.2 Members attaining voting rights at the end of this meeting
+
+### 1.7.3 Members losing voting rights if they have not joined this meeting by the time it ends
+
+### 1.7.4 Members who previously lost voting rights who are attending this meeting
+
+### 1.7.5 Members who have declared a leave of absence
+
+# 2. Future Meetings
+
+## 2.1 Future meeting schedule (Secretary)
+
+- Next Scheduled Teleconferences (Wednesday at 09:00 PT / 12:00 ET / 18:00 CET / **17:00** UTC for 1 hour) - all in 2025
+
+    ```
+    July 16
+    August 20
+    September 17
+    October 15
+    November 19
+    December 17
+    ```
+
+# 3. Discussion
+
+## 3.1 Updates
+
+- Omar shared an update about the discussion centered around collaboration with the Ecma Software and system transparency - Common Lifecycle Enumeration (TC54-TG3) working group. This was a follow-up from the discussion in the issue created by Omar on the ECMA TC 54 GitHub repository: [https://github.com/Ecma-TC54/tg3/issues/4](https://github.com/Ecma-TC54/tg3/issues/4)
+  - Participants emphasized the need for alignment and coordination between efforts.
+  - The group agreed to have dedicated representatives for ongoing communication. The team discussed that Rogue could be that representative from OpenEoX.
+  - We will continue our work as planned and have touch points with CLE working group for alignment on the taxonomy. Their scope is a lot broader than OpenEoX.
+
+## 3.2 Issues / Pull Requests
+
+- Three separate specifications (core, shell, API) will be developed independently.
+- Editors will be responsible for managing contributions and ensuring document alignment.
+- Volunteers for editor roles were confirmed to facilitate the specification process:
+  - Jay White
+  - Stefan Hagen
+  - Thomas Schmidt
+- Omar Santos moved to accept the nomination of the editors.
+  - Justin seconded.
+  - No discussion. No objections. Motion passed.
+- Stefan Hagen moved to allow the editors to provide the list of new editors to the OASIS staff.
+  - Justin seconded.
+  - No discussion. No objections. Motion passed.
+- Thomas emphasized the importance of clear initial descriptions for targeted feedback on technical comments.
+- The discussion highlighted the need for clarity around end-of-life and security support dates to assist users.
+- Concerns arose about using "TBD" in schemas, as it may lead to confusion and hinder effective data communication.
+- We discussed the proposal of [issue #92](https://github.com/oasis-tcs/openeox/issues/92).
+  - This proposal is to provide core.json more flexible for being referenced and used in different scenarios. "required" will cover more simple scenarios.
+  - This would involve using an "anyOf" construct with multiple "required" options, allowing for different combinations of fields like "end_of_life," "end_of_security_support," and "last_update" to be considered mandatory.
+  - There has been no definitive outcome or resolution yet. However, a call to action to continue the conversation in GitHub was made by Omar.
+
+## 3.3 Other Business
+
+N/A
+
+## 3.4 Next steps
+
+- TC chairs and/or editors will provide the list of new editors to the OASIS staff and these meeting minutes.
+
+# 5. Resolutions and Decisions reached (by 10 minutes prior to scheduled meeting end)
+
+## 5.1 End debate of other issues by 10 minutes prior to scheduled meeting end and follow the agenda from this point (Co-Chair)
+
+## 5.2 Review of Decisions Reached (Secretary)
+
+- DECISION TC moves to accept new editors (Jay White, Stefan Hagen, and Thomas Schmidt).
+
+## 5.3 Review of Action Items (Secretary)
+
+- ACTION Omar will create meeting minutes for the TC meeting in September 2024, as those are missing from the repository.
+
+# 6. Next Meeting
+
+  ```
+  July 16, 2025
+  ```
+
+# 8. Adjournment
+
+- Meeting was adjourned.


### PR DESCRIPTION
This pull request adds detailed meeting minutes for the June 18, 2025, meeting of the OpenEoX Technical Committee. The document includes sections on opening activities, future meeting schedules, discussions, resolutions, and next steps.

### Additions to Meeting Documentation:

* **Opening Activities:**
  - Included roll call and quorum verification, showing participation of voting members.
  - Added agenda approval and procedures for the meeting.

* **Discussion Highlights:**
  - Documented updates on collaboration with the Ecma TC54 working group, emphasizing alignment and coordination.
  - Outlined decisions regarding the development of three separate specifications and the nomination of editors.
  - Discussed issue #92, proposing flexible schema constructs for better adaptability in different scenarios.

* **Resolutions and Next Steps:**
  - Recorded decisions such as the acceptance of new editors and action items like creating missing meeting minutes.
  - Provided the schedule for upcoming meetings and adjournment details.

@tschmidtb51 , @justmurphy , @sthagen  - please feel free to edit/add anything missing from these meeting minutes.