### PR TITLE
OpenEoX Core Specification - Initial Structure

### DIFF
--- a/eox-core-v-1-0/prose/edit/etc/bind.txt
+++ b/eox-core-v-1-0/prose/edit/etc/bind.txt
@@ -5,6 +5,7 @@ overview.md
 design-considerations-00.md
 design-considerations-01-construction-principles.md
 design-considerations-02-format-validation.md
+design-considerations-03-date-time.md
 conformance.md
 references.md
 safety-security-and-data-protection.md

--- a/eox-core-v-1-0/prose/edit/etc/bind.txt
+++ b/eox-core-v-1-0/prose/edit/etc/bind.txt
@@ -4,6 +4,7 @@ introduction-01-typographical-conventions.md
 overview.md
 design-considerations-00.md
 design-considerations-01-construction-principles.md
+design-considerations-02-format-validation.md
 conformance.md
 references.md
 safety-security-and-data-protection.md

--- a/eox-core-v-1-0/prose/edit/etc/bind.txt
+++ b/eox-core-v-1-0/prose/edit/etc/bind.txt
@@ -3,6 +3,7 @@ introduction-00.md
 introduction-01-typographical-conventions.md
 overview.md
 design-considerations-00.md
+design-considerations-01-construction-principles.md
 conformance.md
 references.md
 safety-security-and-data-protection.md

--- a/eox-core-v-1-0/prose/edit/etc/bind.txt
+++ b/eox-core-v-1-0/prose/edit/etc/bind.txt
@@ -6,6 +6,7 @@ design-considerations-00.md
 design-considerations-01-construction-principles.md
 design-considerations-02-format-validation.md
 design-considerations-03-date-time.md
+schema-elements-00.md
 conformance.md
 references.md
 safety-security-and-data-protection.md

--- a/eox-core-v-1-0/prose/edit/etc/bind.txt
+++ b/eox-core-v-1-0/prose/edit/etc/bind.txt
@@ -2,6 +2,7 @@ frontmatter.md
 introduction-00.md
 introduction-01-typographical-conventions.md
 overview.md
+design-considerations-00.md
 conformance.md
 references.md
 safety-security-and-data-protection.md

--- a/eox-core-v-1-0/prose/edit/src/design-considerations-00.md
+++ b/eox-core-v-1-0/prose/edit/src/design-considerations-00.md
@@ -1,0 +1,13 @@
+# Design Considerations
+
+OpenEoX is a language to exchange any End-of information formulated in JSON.
+
+The standard is divided into 3 parts:
+
+- OpenEoX Core (this specification): contain the OpenEoX core information and intended to be imported by other standards which will provide the
+  product context needed.
+  Optionally, the product context can be omitted if the product itself provides the information, e.g. through in an SNMP or HTTPS response.
+- OpenEoX Shell: binding OpenEoX core information to products.
+  Such combination is called an OpenEoX statement.
+  The OpenEoX Shell forms the so called standalone mode in OpenEoX.
+- OpenEoX API: deals with the distribution of OpenEoX Core and OpenEoX Shell data.

--- a/eox-core-v-1-0/prose/edit/src/design-considerations-01-construction-principles.md
+++ b/eox-core-v-1-0/prose/edit/src/design-considerations-01-construction-principles.md
@@ -1,0 +1,19 @@
+## Construction Principles
+
+TODO:
+
+- add generic paragraph about OpenEoX Core
+- add paragraph about JSON Schema
+- optional: add paragraph about imported/references schemas (should be none here)
+
+Even though not all - especially the referenced - JSON schemas prohibit specifically additional properties and custom keywords,
+it is strongly recommended not to use them.
+Suggestions for new fields or values SHOULD be made through issues in the TC's GitHub.
+The JSON schemas defined in this standard do not allow the use of additional properties and custom keywords.
+
+> The standardized fields allow for scalability across different issuing parties and dramatically reduce the human effort and
+> need for dedicated parsers as well as other tools on the side of the consuming parties.
+
+TODO:
+
+- describe subsequent sections

--- a/eox-core-v-1-0/prose/edit/src/design-considerations-02-format-validation.md
+++ b/eox-core-v-1-0/prose/edit/src/design-considerations-02-format-validation.md
@@ -1,0 +1,34 @@
+## Format Validation
+
+The JSON schema 2020-12 dialect per default uses the `format` keyword just as annotation.
+To be able to ensure that the format constraints are validated as intended, the following metaschema is defined.
+
+```
+  {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://docs.oasis-open.org/openeox/eox-core/tbd/schema/meta.json",
+    "$dynamicAnchor": "meta",
+    "$vocabulary": {
+      "https://json-schema.org/draft/2020-12/vocab/core": true,
+      "https://json-schema.org/draft/2020-12/vocab/format-assertion": true
+    },
+    "allOf": [
+      { "$ref": "https://json-schema.org/draft/2020-12/meta/core" },
+      { "$ref": "https://json-schema.org/draft/2020-12/meta/format-assertion" }
+    ]
+  }
+```
+
+It is then consequently used in all JSON schemas defined in this standard and replaces the reference to the JSON schema 2020-12.
+
+```
+  {
+    "$schema": "https://docs.oasis-open.org/openeox/eox-core/tbd/schema/meta.json",
+    // ...
+  }
+```
+
+The format validation is enforced by setting the corresponding vocabulary as required.
+
+> If a library used to parse, modify or create OpenEoX content is unable to deal with this meta schema, it could reach the objective by
+> interpreting the schema as JSON schema 2020-12 dialect and enforcing the format validation via its implementation.

--- a/eox-core-v-1-0/prose/edit/src/design-considerations-02-format-validation.md
+++ b/eox-core-v-1-0/prose/edit/src/design-considerations-02-format-validation.md
@@ -6,7 +6,7 @@ To be able to ensure that the format constraints are validated as intended, the 
 ```
   {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://docs.oasis-open.org/openeox/eox-core/tbd/schema/meta.json",
+    "$id": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json",
     "$dynamicAnchor": "meta",
     "$vocabulary": {
       "https://json-schema.org/draft/2020-12/vocab/core": true,
@@ -23,7 +23,7 @@ It is then consequently used in all JSON schemas defined in this standard and re
 
 ```
   {
-    "$schema": "https://docs.oasis-open.org/openeox/eox-core/tbd/schema/meta.json",
+    "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json",
     // ...
   }
 ```

--- a/eox-core-v-1-0/prose/edit/src/design-considerations-03-date-time.md
+++ b/eox-core-v-1-0/prose/edit/src/design-considerations-03-date-time.md
@@ -1,0 +1,19 @@
+## Date and Time
+
+This standard uses the `date-time` format as defined in JSON Schema Draft 2020-12 Section 7.3.1.
+In accordance with [cite](#RFC3339) and [cite](#ISO8601-1), the following rules apply:
+
+* The letter `T` separating the date and time SHALL be upper case.
+* The separator between date and time MUST be the letter `T`.
+* The letter `Z` indicating the timezone UTC SHALL be upper case.
+* Fractions of seconds are allowed as specified in the standards mention above with the full stop (`.`) as separator.
+* Empty timezones MUST NOT be used.
+* The ABNF of [cite](#RFC3339), section 5.6 applies.
+
+In contrast to the aforementioned standards, leap seconds MUST NOT be used.
+
+  > While a full support of [cite](#RFC3339) would be preferred, significant challenges have been mentioned by implementers
+  > as most libraries are lacking the support for leap seconds.
+  > To ensure interoperability, the decision was made to prohibit leap seconds.
+
+-------

--- a/eox-core-v-1-0/prose/edit/src/frontmatter.md
+++ b/eox-core-v-1-0/prose/edit/src/frontmatter.md
@@ -39,6 +39,8 @@ This prose specification is one component of a Work Product that also includes:
 
 * OpenEOX Core JSON schema: https://docs.oasis-open.org/openeox/eox-core/v1.0/csd01/schema/eox-core.json. \
 Latest stage: https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/eox-core.json.
+* OpenEOX Meta JSON schema: https://docs.oasis-open.org/openeox/eox-core/v1.0/csd01/schema/meta.json. \
+Latest stage: https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json.
 
 #### Related work:
 This specification is related to
@@ -48,6 +50,7 @@ This specification is related to
 #### Declared JSON namespaces:
 
 * [https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/eox-core.json](https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/eox-core.json)
+* [https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json](https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json)
 
 
 #### Abstract:

--- a/eox-core-v-1-0/prose/edit/src/frontmatter.md
+++ b/eox-core-v-1-0/prose/edit/src/frontmatter.md
@@ -7,7 +7,7 @@
 
 ## Committee Specification Draft 01
 
-## 16 July 2025
+## 20 August 2025
 
 #### This stage:
 https://docs.oasis-open.org/openeox/eox-core/v1.0/csd01/eox-core-v1.0-csd01.md (Authoritative) \

--- a/eox-core-v-1-0/prose/edit/src/revision-history.md
+++ b/eox-core-v-1-0/prose/edit/src/revision-history.md
@@ -11,5 +11,6 @@ toc:
 | Revision                     | Date       | Editor                                         | Changes Made                      |
 |:-----------------------------|:-----------|:-----------------------------------------------|:----------------------------------|
 | eox-core-v1.0-wd20250716-dev | 2025-07-16 | Jautau White, Stefan Hagen, and Thomas Schmidt | Preparing initial Editor Revision |
+| eox-core-v1.0-wd20250820-dev | 2025-08-20 | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision with first structure |
 
 -------

--- a/eox-core-v-1-0/prose/edit/src/schema-elements-00.md
+++ b/eox-core-v-1-0/prose/edit/src/schema-elements-00.md
@@ -1,0 +1,26 @@
+# Schema Elements
+
+The OpenEoX Core schema describes how to represent OpenEoX core information as a JSON document.
+
+The OpenEoX Core schema Version 1.0 builds on the JSON Schema draft 2020-12 rules extended by the format validation
+enforcement (see [sec](#format-validation)).
+
+```
+  "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json",
+```
+
+The schema identifier is:
+
+```
+  "$id": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
+```
+
+The further documentation of the schema is organized via Definitions and Properties.
+
+* Definitions provide types that extend the JSON schema model
+* Properties use these types to support assembling OpenEoX core information
+
+Types and properties together provide the vocabulary for the domain specific language supporting OpenEoX information.
+
+The four mandatory properties are `$schema`, `end_of_life`, `end_of_security_support`, and `last_updated`.
+The additional property, `end_of_sales`, is optional.

--- a/eox-core-v-1-0/schema/eox-core.json
+++ b/eox-core-v-1-0/schema/eox-core.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.oasis-open.org/openeox/eox-core/tbd/schema/meta.json",
-  "$id": "https://docs.oasis-open.org/openeox/tbd/schema/core.json",
+  "$schema": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json",
+  "$id": "https://docs.oasis-open.org/openeox/v1.0/schema/core.json",
   "title": "EoX Information - Core",
   "description": "The schema for representing End-of-Life (EoL), End-of-Security-Support (EoSSec) and other End-of information in OpenEoX.",
   "type": "object",
@@ -10,7 +10,7 @@
       "description": "Specifies the schema the JSON object must be valid against.",
       "type": "string",
       "enum": [
-        "https://docs.oasis-open.org/openeox/tbd/schema/core.json"
+        "https://docs.oasis-open.org/openeox/v1.0/schema/core.json"
       ]
     },
     "timestamp_t": {

--- a/eox-core-v-1-0/schema/eox-core.json
+++ b/eox-core-v-1-0/schema/eox-core.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://docs.oasis-open.org/openeox/eox-core/tbd/schema/meta.json",
   "$id": "https://docs.oasis-open.org/openeox/tbd/schema/core.json",
   "title": "EoX Information - Core",
   "description": "The schema for representing End-of-Life (EoL), End-of-Security-Support (EoSSec) and other End-of information in OpenEoX.",

--- a/eox-core-v-1-0/schema/meta.json
+++ b/eox-core-v-1-0/schema/meta.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://docs.oasis-open.org/openeox/eox-core/tbd/schema/meta.json",
+  "$id": "https://docs.oasis-open.org/openeox/eox-core/v1.0/schema/meta.json",
   "$dynamicAnchor": "meta",
   "$vocabulary": {
     "https://json-schema.org/draft/2020-12/vocab/core": true,

--- a/eox-core-v-1-0/schema/meta.json
+++ b/eox-core-v-1-0/schema/meta.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://docs.oasis-open.org/openeox/eox-core/tbd/schema/meta.json",
+  "$dynamicAnchor": "meta",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2020-12/vocab/core": true,
+    "https://json-schema.org/draft/2020-12/vocab/format-assertion": true
+  },
+  "allOf": [
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/core" },
+    { "$ref": "https://json-schema.org/draft/2020-12/meta/format-assertion" }
+  ]
+}


### PR DESCRIPTION
- add rough content for design considerations
- add rough content for construction principles
- add content of format validation
- add meta schema
- update eox-core schema to use meta schema
- add content of date and time (similar to CSAF)
- add content for Schema Elements
- add version `v1.0` to all JSON schemas in this structure
- adapt prose
- adapt frontmatter to show meta schema