### PR TITLE
Add meeting minutes for TC 2025-10-15

### DIFF
--- a/meeting-minutes/2025/2025-10-15.md
+++ b/meeting-minutes/2025/2025-10-15.md
@@ -34,7 +34,7 @@ Quorum requires participation of 6 or more of the 10 voting members (including t
 | Thomas     | Schmidt     | Federal Office for Information Security (BSI) Germany       | Voting Member | Yes     |
 | Tobias     | Limmer      | Siemens                                                     | Member        | No      |
 
-Quorum was reached (7 voting members present).
+Quorum was reached (6 voting members present).
 
 ## 1.3 Procedures for this meeting (Moderator)
 


### PR DESCRIPTION
- [x] Add meeting summary of 2025-10-15 (monthly TC meeting)

@tschmidtb51 Please review if the meeting attendance was captured correctly.

Unfortunately the meeting recording and AI summarization was not captured 100% properly this time (some strange bug), so  I tried my best to recreate the meeting minutes.