### PR TITLE
Tool: Ensure bump tool works with changed outline or prose

### DIFF
--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -32,7 +32,7 @@ SEMI = ';'
 SPACE = ' '
 CSEP = COMMA + SPACE
 TM = '™'
-LANG_CODE = 'en_US'
+LANG_CODE = 'C'
 
 # Generate tuple with English month names in title case
 locale.setlocale(locale.LC_ALL, LANG_CODE)

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -33,344 +33,350 @@ tool = pathlib.Path(__file__)
 path = tool.relative_to(here)
 usage = f'usage: {path} [--commit] "DD Month YYYY"'
 
-args = sys.argv[1:]
 
-if not args:
-    print(usage)
-    sys.exit(0)
+def main(args: list[str]) -> int:
+    """Drive the transform to bump the dates based on the given argument."""
+    if not args:
+        print(usage)
+        sys.exit(0)
 
-commit = False
-for slot, arg in enumerate(args):
-    if arg.lower() == '--commit':
-        commit = True
-        del args[slot]
+    commit = False
+    for slot, arg in enumerate(args):
+        if arg.lower() == '--commit':
+            commit = True
+            del args[slot]
 
-try:
-    DD, Month, YYYY = args[0].split(SPACE)
-except ValueError:
-    print(usage)
-    print(f'ERROR: Parsing date value ({args[0]})')
-    sys.exit(2)
-except IndexError:
-    print(usage)
-    print('ERROR: Not enough arguments')
-    sys.exit(2)
+    try:
+        DD, Month, YYYY = args[0].split(SPACE)
+    except ValueError:
+        print(usage)
+        print(f'ERROR: Parsing date value ({args[0]})')
+        return 2
+    except IndexError:
+        print(usage)
+        print('ERROR: Not enough arguments')
+        return 2
 
-PUB_DAY = DD
-PUB_MONTH_EN = Month.title()
-PUB_YEAR = YYYY
+    PUB_DAY = DD
+    PUB_MONTH_EN = Month.title()
+    PUB_YEAR = YYYY
 
-if len(PUB_DAY) != 2:
-    print('ERROR: Day part must be two-digits (zero-padded)')
-    sys.exit(2)
+    if len(PUB_DAY) != 2:
+        print('ERROR: Day part must be two-digits (zero-padded)')
+        return 2
 
-try:
-    d = int(PUB_DAY)
-    if not 1 <= d <= 31:
-        raise ValueError
-except ValueError:
-    print('ERROR: Day part must be an integral number in [1, 31]')
-    sys.exit(2)
+    try:
+        d = int(PUB_DAY)
+        if not 1 <= d <= 31:
+            raise ValueError
+    except ValueError:
+        print('ERROR: Day part must be an integral number in [1, 31]')
+        return 2
 
-if PUB_MONTH_EN not in MONTHS_EN:
-    print(f'ERROR: English month part must be in ({CSEP.join(MONTHS_EN)})')
-    sys.exit(2)
+    if PUB_MONTH_EN not in MONTHS_EN:
+        print(f'ERROR: English month part must be in ({CSEP.join(MONTHS_EN)})')
+        return 2
 
-PUB_MONTH = '00'
-for number, name in enumerate(MONTHS_EN, start=1):
-    if PUB_MONTH_EN == name:
-        PUB_MONTH = f'{number :02d}'
+    PUB_MONTH = '00'
+    for number, name in enumerate(MONTHS_EN, start=1):
+        if PUB_MONTH_EN == name:
+            PUB_MONTH = f'{number :02d}'
 
-if PUB_MONTH == '00':
-    print('ERROR: English month part to %m mapping failed')
-    sys.exit(1)
+    if PUB_MONTH == '00':
+        print('ERROR: English month part to %m mapping failed')
+        return 1
 
-if len(PUB_YEAR) != 4:
-    print('ERROR: Year part must be four-digits')
-    sys.exit(2)
+    if len(PUB_YEAR) != 4:
+        print('ERROR: Year part must be four-digits')
+        return 2
 
-now = dti.datetime.now(dti.UTC)
-this_year = now.year
+    now = dti.datetime.now(dti.UTC)
+    this_year = now.year
 
-try:
-    y = int(PUB_YEAR)
-    if y < this_year - 1:
-        raise ValueError
-except ValueError:
-    print(f'ERROR: Year part must be an integral number >= {this_year - 1}')
-    sys.exit(2)
+    try:
+        y = int(PUB_YEAR)
+        if y < this_year - 1:
+            raise ValueError
+    except ValueError:
+        print(f'ERROR: Year part must be an integral number >= {this_year - 1}')
+        return 2
 
-try:
-    m = int(PUB_MONTH)
-    if not 1 <= m <= 12:
-        raise ValueError
-except ValueError:
-    print('ERROR: Month part must map to an integral number in [1, 12]')
-    sys.exit(1)
+    try:
+        m = int(PUB_MONTH)
+        if not 1 <= m <= 12:
+            raise ValueError
+    except ValueError:
+        print('ERROR: Month part must map to an integral number in [1, 12]')
+        return 1
 
-_, max_days_of_month = cal.monthrange(y, m)
-if d > max_days_of_month:
-    print(f'ERROR: Day part must be inside days of month [1, {max_days_of_month}]')
-    sys.exit(2)
+    _, max_days_of_month = cal.monthrange(y, m)
+    if d > max_days_of_month:
+        print(f'ERROR: Day part must be inside days of month [1, {max_days_of_month}]')
+        return 2
 
-if not commit:
-    print('INFO: Dry-run only - only diffs are shown and no files changed.')
-    print()
-else:
-    print('INFO: Commit mode - the magical five files will be bumped.')
-    print()
+    if not commit:
+        print('INFO: Dry-run only - only diffs are shown and no files changed.')
+        print()
+    else:
+        print('INFO: Commit mode - the magical five files will be bumped.')
+        print()
 
-PUB_DATE = f'{PUB_DAY} {PUB_MONTH_EN} {PUB_YEAR}'
-DEBUG = bool(os.getenv('BUMP_DEBUG', ''))
+    PUB_DATE = f'{PUB_DAY} {PUB_MONTH_EN} {PUB_YEAR}'
+    DEBUG = bool(os.getenv('BUMP_DEBUG', ''))
 
-# Configuration and runtime parameter candidates:
-PDF_BOOKMATTER_IN = pathlib.Path('etc/liitos/bookmatter.tex.in')
-PDF_META_YAML = pathlib.Path('etc/liitos/meta.yml')
-PDF_SETUP_IN = pathlib.Path('etc/liitos/setup.tex.in')
-SRC_FRONTMATTER = pathlib.Path('src/frontmatter.md')
-SRC_HISTORY = pathlib.Path('src/revision-history.md')
+    # Configuration and runtime parameter candidates:
+    PDF_BOOKMATTER_IN = pathlib.Path('etc/liitos/bookmatter.tex.in')
+    PDF_META_YAML = pathlib.Path('etc/liitos/meta.yml')
+    PDF_SETUP_IN = pathlib.Path('etc/liitos/setup.tex.in')
+    SRC_FRONTMATTER = pathlib.Path('src/frontmatter.md')
+    SRC_HISTORY = pathlib.Path('src/revision-history.md')
 
-any_changes = False
+    any_changes = False
 
-with open(PDF_BOOKMATTER_IN, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-    lines = [line.rstrip(NL) for line in source.readlines()]
+    with open(PDF_BOOKMATTER_IN, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
+        lines = [line.rstrip(NL) for line in source.readlines()]
 
-bumped = []
-for line in lines:
-    prefix = r'\subsection*{'
-    postfix = r'}\label{pub-date}'
-    # \subsection*{21 January 2026}\label{pub-date}
-    if line.startswith(prefix) and line.endswith(postfix):
-        pub_date = line.replace(prefix, '').replace(postfix, '')
-        DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-        bumped.append(prefix + PUB_DATE + postfix)
-        DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
-        continue
-
-    prefix = 'Hagen, and Thomas Schmidt. '
-    postfix = '. OASIS Committee Specification'
-    # Hagen, and Thomas Schmidt. 21 January 2026. OASIS Committee Specification
-    if line.startswith(prefix) and line.endswith('. OASIS Committee Specification'):
-        pub_date = line.replace(prefix, '').replace('. OASIS Committee Specification', '')
-        DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-        bumped.append(prefix + PUB_DATE + '. OASIS Committee Specification')
-        DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
-        continue
-
-    bumped.append(line)
-
-if lines != bumped:
-    if not any_changes:
-        any_changes = True
-    print(f'# - - - 8< - -(( {PDF_BOOKMATTER_IN} )) - - - - - - - - - - - - - - >')
-    print()
-    sys.stdout.writelines(difflib.unified_diff(
-        tuple(line + NL for line in lines),
-        tuple(line + NL for line in bumped),
-        fromfile='bookmatter.tex.in',
-        tofile='bookmatter-bumped.tex.in',
-    ))
-    if commit:
-        with open(PDF_BOOKMATTER_IN, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-            target.write(NL.join(bumped) + NL)
-else:
-    print(f'INFO: No changes to {PDF_BOOKMATTER_IN}')
-
-with open(PDF_META_YAML, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-    lines = [line.rstrip(NL) for line in source.readlines()]
-
-bumped = []
-for line in lines:
-    #     footer_outer_field_normal_pages: 21 January 2026 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
-    prefix = '    footer_outer_field_normal_pages: '
-    postfix = r' - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}'
-    if line.startswith(prefix) and line.endswith(postfix):
-        pub_date = line.replace(prefix, '').replace(postfix, '')
-        DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-        bumped.append(prefix + PUB_DATE + postfix)
-        DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
-        continue
-
-    bumped.append(line)
-
-if lines != bumped:
-    if not any_changes:
-        any_changes = True
-    print()
-    print(f'# - - - 8< - -(( {PDF_META_YAML} )) - - - - - - - - - - - - - - - - - - >')
-    print()
-    sys.stdout.writelines(difflib.unified_diff(
-        tuple(line + NL for line in lines),
-        tuple(line + NL for line in bumped),
-        fromfile='meta.yml',
-        tofile='meta-bumped.yml',
-    ))
-    if commit:
-        with open(PDF_META_YAML, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-            target.write(NL.join(bumped) + NL)
-else:
-    print(f'INFO: No changes to {PDF_META_YAML}')
-
-with open(PDF_SETUP_IN, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-    lines = [line.rstrip(NL) for line in source.readlines()]
-
-bumped = []
-for line in lines:
-    prefix = r'  \cfoot*{\upshape{\scriptsize Copyright © OASIS Open '
-    postfix = r'. All Rights Reserved.}}'
-    #   \cfoot*{\upshape{\scriptsize Copyright © OASIS Open 2026. All Rights Reserved.}}
-    if line.startswith(prefix) and line.endswith(postfix):
-        copyright_year = line.replace(prefix, '').replace(postfix, '')
-        DEBUG and print(f'DEBUG: Found prior copyright-year ({copyright_year})')
-        bumped.append(prefix + PUB_YEAR + postfix)
-        DEBUG and print(f'DEBUG: Bumped to ({PUB_YEAR})')
-        continue
-
-    bumped.append(line)
-
-if lines != bumped:
-    if not any_changes:
-        any_changes = True
-    print()
-    print(f'# - - - 8< - -(( {PDF_SETUP_IN} )) - - - - - - - - - - - - - - >')
-    print()
-    sys.stdout.writelines(difflib.unified_diff(
-        tuple(line + NL for line in lines),
-        tuple(line + NL for line in bumped),
-        fromfile='setup.tex.in',
-        tofile='setup-bumped.tex.in',
-    ))
-    if commit:
-        with open(PDF_SETUP_IN, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-            target.write(NL.join(bumped) + NL)
-else:
-    print(f'INFO: No changes to {PDF_SETUP_IN}')
-
-
-with open(SRC_FRONTMATTER, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-    lines = [line.rstrip(NL) for line in source.readlines()]
-
-bumped = []
-for line in lines:
-    # ## 21 January 2026
-    prefix = '## '
-    postfix = ''
-    if line.startswith(prefix):
-        try:
-            day = line.replace(prefix, '').replace(postfix, '').split(SPACE)[0]
-            int(day)
+    bumped = []
+    for line in lines:
+        prefix = r'\subsection*{'
+        postfix = r'}\label{pub-date}'
+        # \subsection*{21 January 2026}\label{pub-date}
+        if line.startswith(prefix) and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
             DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
             bumped.append(prefix + PUB_DATE + postfix)
             DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
             continue
-        except ValueError:
-            pass
 
-    # 21 January 2026.
-    prefix = ''
-    postfix = '.'
-    if 11 < len(line) < 19 and line.endswith(postfix):
-        pub_date = line.replace(prefix, '').replace(postfix, '')
-        try:
-            a_day, a_month_name, a_year = pub_date.split(SPACE)
-        except (ValueError, IndexError):
+        prefix = 'Hagen, and Thomas Schmidt. '
+        postfix = '. OASIS Committee Specification'
+        # Hagen, and Thomas Schmidt. 21 January 2026. OASIS Committee Specification
+        if line.startswith(prefix) and line.endswith('. OASIS Committee Specification'):
+            pub_date = line.replace(prefix, '').replace('. OASIS Committee Specification', '')
+            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + PUB_DATE + '. OASIS Committee Specification')
+            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            continue
+
+        bumped.append(line)
+
+    if lines != bumped:
+        if not any_changes:
+            any_changes = True
+        print(f'# - - - 8< - -(( {PDF_BOOKMATTER_IN} )) - - - - - - - - - - - - - - >')
+        print()
+        sys.stdout.writelines(difflib.unified_diff(
+            tuple(line + NL for line in lines),
+            tuple(line + NL for line in bumped),
+            fromfile='bookmatter.tex.in',
+            tofile='bookmatter-bumped.tex.in',
+        ))
+        if commit:
+            with open(PDF_BOOKMATTER_IN, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
+                target.write(NL.join(bumped) + NL)
+    else:
+        print(f'INFO: No changes to {PDF_BOOKMATTER_IN}')
+
+    with open(PDF_META_YAML, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
+        lines = [line.rstrip(NL) for line in source.readlines()]
+
+    bumped = []
+    for line in lines:
+        #     footer_outer_field_normal_pages: 21 January 2026 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
+        prefix = '    footer_outer_field_normal_pages: '
+        postfix = r' - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}'
+        if line.startswith(prefix) and line.endswith(postfix):
+            pub_date = line.replace(prefix, '').replace(postfix, '')
+            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + PUB_DATE + postfix)
+            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            continue
+
+        bumped.append(line)
+
+    if lines != bumped:
+        if not any_changes:
+            any_changes = True
+        print()
+        print(f'# - - - 8< - -(( {PDF_META_YAML} )) - - - - - - - - - - - - - - - - - - >')
+        print()
+        sys.stdout.writelines(difflib.unified_diff(
+            tuple(line + NL for line in lines),
+            tuple(line + NL for line in bumped),
+            fromfile='meta.yml',
+            tofile='meta-bumped.yml',
+        ))
+        if commit:
+            with open(PDF_META_YAML, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
+                target.write(NL.join(bumped) + NL)
+    else:
+        print(f'INFO: No changes to {PDF_META_YAML}')
+
+    with open(PDF_SETUP_IN, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
+        lines = [line.rstrip(NL) for line in source.readlines()]
+
+    bumped = []
+    for line in lines:
+        prefix = r'  \cfoot*{\upshape{\scriptsize Copyright © OASIS Open '
+        postfix = r'. All Rights Reserved.}}'
+        #   \cfoot*{\upshape{\scriptsize Copyright © OASIS Open 2026. All Rights Reserved.}}
+        if line.startswith(prefix) and line.endswith(postfix):
+            copyright_year = line.replace(prefix, '').replace(postfix, '')
+            DEBUG and print(f'DEBUG: Found prior copyright-year ({copyright_year})')
+            bumped.append(prefix + PUB_YEAR + postfix)
+            DEBUG and print(f'DEBUG: Bumped to ({PUB_YEAR})')
+            continue
+
+        bumped.append(line)
+
+    if lines != bumped:
+        if not any_changes:
+            any_changes = True
+        print()
+        print(f'# - - - 8< - -(( {PDF_SETUP_IN} )) - - - - - - - - - - - - - - >')
+        print()
+        sys.stdout.writelines(difflib.unified_diff(
+            tuple(line + NL for line in lines),
+            tuple(line + NL for line in bumped),
+            fromfile='setup.tex.in',
+            tofile='setup-bumped.tex.in',
+        ))
+        if commit:
+            with open(PDF_SETUP_IN, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
+                target.write(NL.join(bumped) + NL)
+    else:
+        print(f'INFO: No changes to {PDF_SETUP_IN}')
+
+
+    with open(SRC_FRONTMATTER, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
+        lines = [line.rstrip(NL) for line in source.readlines()]
+
+    bumped = []
+    for line in lines:
+        # ## 21 January 2026
+        prefix = '## '
+        postfix = ''
+        if line.startswith(prefix):
+            try:
+                day = line.replace(prefix, '').replace(postfix, '').split(SPACE)[0]
+                int(day)
+                pub_date = line.replace(prefix, '').replace(postfix, '')
+                DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
+                bumped.append(prefix + PUB_DATE + postfix)
+                DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+                continue
+            except ValueError:
+                pass
+
+        # 21 January 2026.
+        prefix = ''
+        postfix = '.'
+        if 11 < len(line) < 19 and line.endswith(postfix):
+            pub_date = line.replace(prefix, '').replace(postfix, '')
+            try:
+                a_day, a_month_name, a_year = pub_date.split(SPACE)
+            except (ValueError, IndexError):
+                bumped.append(line)
+                continue
+            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + PUB_DATE + postfix)
+            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            continue
+
+        # Copyright &copy; OASIS Open 2026. All Rights Reserved.
+        prefix = 'Copyright &copy; OASIS Open '
+        postfix = '. All Rights Reserved.'
+        if line.startswith(prefix) and line.endswith(postfix):
+            pub_date = line.replace(prefix, '').replace(postfix, '')
+            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + PUB_YEAR + postfix)
+            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            continue
+
+        bumped.append(line)
+
+    if lines != bumped:
+        if not any_changes:
+            any_changes = True
+        print()
+        print(f'# - - - 8< - -(( {SRC_FRONTMATTER} )) - - - - - - - - - - - - - - - - - - >')
+        print()
+        sys.stdout.writelines(difflib.unified_diff(
+            tuple(line + NL for line in lines),
+            tuple(line + NL for line in bumped),
+            fromfile='frontmatter.md',
+            tofile='frontmatter-bumped.md',
+        ))
+        if commit:
+            with open(SRC_FRONTMATTER, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
+                target.write(NL.join(bumped) + NL)
+    else:
+        print(f'INFO: No changes to {SRC_FRONTMATTER}')
+
+    with open(SRC_HISTORY, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
+        lines = [line.rstrip(NL) for line in source.readlines()]
+
+    bumped = []
+    do_amend = True
+    past_table = None  # State machine: None -> False -> True -> None
+    trigger_prefix = '|:-----------------------------'
+    prefix = '| eox-core-v1.0-wd'
+    in_between = f'{PUB_YEAR}{PUB_MONTH}{PUB_DAY}-dev | {PUB_YEAR}-{PUB_MONTH}-{PUB_DAY}'
+    stop_token = prefix + in_between
+    postfix = ' | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |'
+    for line in lines:
+        # | eox-core-v1.0-wd20260121-dev | 2026-01-21 | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |
+        # <-- append here when past_table is True
+        if line.startswith(trigger_prefix) and past_table is None:
+            past_table = False
             bumped.append(line)
             continue
-        DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-        bumped.append(prefix + PUB_DATE + postfix)
-        DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
-        continue
 
-    # Copyright &copy; OASIS Open 2026. All Rights Reserved.
-    prefix = 'Copyright &copy; OASIS Open '
-    postfix = '. All Rights Reserved.'
-    if line.startswith(prefix) and line.endswith(postfix):
-        pub_date = line.replace(prefix, '').replace(postfix, '')
-        DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-        bumped.append(prefix + PUB_YEAR + postfix)
-        DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
-        continue
+        if line.startswith(prefix) and past_table is False:
+            bumped.append(line)
+            if line.startswith(stop_token):
+                do_amend = False
+            continue
 
-    bumped.append(line)
+        if not line.strip(SPACE + DASH) and past_table is False:
+            DEBUG and print('DEBUG: Found empty line following revision history table')
+            if do_amend:
+                bumped.append(prefix + in_between + postfix)
+                DEBUG and print(f'DEBUG: Appended with in_between ({in_between})')
+                do_amend = False
+            else:
+                DEBUG and print(f'DEBUG: Did NOT append duplicate ({in_between})')
+            bumped.append(line)
+            continue
 
-if lines != bumped:
-    if not any_changes:
-        any_changes = True
-    print()
-    print(f'# - - - 8< - -(( {SRC_FRONTMATTER} )) - - - - - - - - - - - - - - - - - - >')
-    print()
-    sys.stdout.writelines(difflib.unified_diff(
-        tuple(line + NL for line in lines),
-        tuple(line + NL for line in bumped),
-        fromfile='frontmatter.md',
-        tofile='frontmatter-bumped.md',
-    ))
-    if commit:
-        with open(SRC_FRONTMATTER, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-            target.write(NL.join(bumped) + NL)
-else:
-    print(f'INFO: No changes to {SRC_FRONTMATTER}')
-
-with open(SRC_HISTORY, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-    lines = [line.rstrip(NL) for line in source.readlines()]
-
-bumped = []
-do_amend = True
-past_table = None  # State machine: None -> False -> True -> None
-trigger_prefix = '|:-----------------------------'
-prefix = '| eox-core-v1.0-wd'
-in_between = f'{PUB_YEAR}{PUB_MONTH}{PUB_DAY}-dev | {PUB_YEAR}-{PUB_MONTH}-{PUB_DAY}'
-stop_token = prefix + in_between
-postfix = ' | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |'
-for line in lines:
-    # | eox-core-v1.0-wd20260121-dev | 2026-01-21 | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |
-    # <-- append here when past_table is True
-    if line.startswith(trigger_prefix) and past_table is None:
-        past_table = False
         bumped.append(line)
-        continue
 
-    if line.startswith(prefix) and past_table is False:
-        bumped.append(line)
-        if line.startswith(stop_token):
-            do_amend = False
-        continue
-
-    if not line.strip(SPACE + DASH) and past_table is False:
-        DEBUG and print('DEBUG: Found empty line following revision history table')
-        if do_amend:
-            bumped.append(prefix + in_between + postfix)
-            DEBUG and print(f'DEBUG: Appended with in_between ({in_between})')
-            do_amend = False
-        else:
-            DEBUG and print(f'DEBUG: Did NOT append duplicate ({in_between})')
-        bumped.append(line)
-        continue
-
-    bumped.append(line)
-
-if lines != bumped:
-    if not any_changes:
-        any_changes = True
-    print()
-    print(f'# - - - 8< - -(( {SRC_HISTORY} )) - - - - - - - - - - - - - - - - - - >')
-    print()
-    sys.stdout.writelines(difflib.unified_diff(
-        tuple(line + NL for line in lines),
-        tuple(line + NL for line in bumped),
-        fromfile='revision-history.md',
-        tofile='revision-history-bumped.md',
-    ))
-    if commit:
-        with open(SRC_HISTORY, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-            target.write(NL.join(bumped) + NL)
+    if lines != bumped:
+        if not any_changes:
+            any_changes = True
         print()
-else:
-    print(f'INFO: No changes to {SRC_HISTORY}')
+        print(f'# - - - 8< - -(( {SRC_HISTORY} )) - - - - - - - - - - - - - - - - - - >')
+        print()
+        sys.stdout.writelines(difflib.unified_diff(
+            tuple(line + NL for line in lines),
+            tuple(line + NL for line in bumped),
+            fromfile='revision-history.md',
+            tofile='revision-history-bumped.md',
+        ))
+        if commit:
+            with open(SRC_HISTORY, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
+                target.write(NL.join(bumped) + NL)
+            print()
+    else:
+        print(f'INFO: No changes to {SRC_HISTORY}')
 
-print()
-if any_changes:
-    print('INFO: Bumped - OK') if commit else print('INFO: Dry-Bumped - OK')
-else:
-    print('INFO: No changes - no commit - OK') if commit else print('INFO: No dry-changes - nothing would be committed - OK')
+    print()
+    if any_changes:
+        print('INFO: Bumped - OK') if commit else print('INFO: Dry-Bumped - OK')
+    else:
+        print('INFO: No changes - no commit - OK') if commit else print('INFO: No dry-changes - nothing would be committed - OK')
+
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -82,7 +82,7 @@ def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int,
         return 2, messages
 
     if len(job[PUB_DAY_STR]) != 2:
-        print('ERROR: Day part must be two-digits (zero-padded)')
+        messages.append('ERROR: Day part must be two-digits (zero-padded)')
         return 2, messages
 
     try:
@@ -90,11 +90,11 @@ def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int,
         if not 1 <= job[PUB_DAY_INT] <= 31:
             raise ValueError
     except ValueError:
-        print('ERROR: Day part must be an integral number in [1, 31]')
+        messages.append('ERROR: Day part must be an integral number in [1, 31]')
         return 2, messages
 
     if job[PUB_MONTH_NAME_EN] not in month_names:
-        print(f'ERROR: English month part must be in ({CSEP.join(month_names)})')
+        messages.append(f'ERROR: English month part must be in ({CSEP.join(month_names)})')
         return 2, messages
 
     job[PUB_MONTH_STR] = '00'
@@ -103,11 +103,11 @@ def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int,
             job[PUB_MONTH_STR] = f'{number :02d}'
 
     if job[PUB_MONTH_STR] == '00':
-        print('ERROR: English month part to %m mapping failed')
+        messages.append('ERROR: English month part to %m mapping failed')
         return 1, messages
 
     if len(year_str) != 4:
-        print('ERROR: Year part must be four-digits')
+        messages.append('ERROR: Year part must be four-digits')
         return 2, messages
 
     now = dti.datetime.now(dti.UTC)
@@ -117,7 +117,7 @@ def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int,
         if job[PUB_YEAR_INT] < this_year - 1:
             raise ValueError
     except ValueError:
-        print(f'ERROR: Year part must be an integral number >= {this_year - 1}')
+        messages.append(f'ERROR: Year part must be an integral number >= {this_year - 1}')
         return 2, messages
 
     try:
@@ -125,12 +125,12 @@ def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int,
         if not 1 <= job[PUB_MONTH_INT] <= 12:
             raise ValueError
     except ValueError:
-        print('ERROR: Month part must map to an integral number in [1, 12]')
+        messages.append('ERROR: Month part must map to an integral number in [1, 12]')
         return 1, messages
 
     _, max_days_of_month = cal.monthrange(job[PUB_YEAR_INT], job[PUB_MONTH_INT])
     if job[PUB_DAY_INT] > max_days_of_month:
-        print(f'ERROR: Day part must be inside days of month [1, {max_days_of_month}]')
+        messages.append(f'ERROR: Day part must be inside days of month [1, {max_days_of_month}]')
         return 2, messages
 
     job[PUB_DATE] = f'{job[PUB_DAY_STR]}{SPACE}{job[PUB_MONTH_NAME_EN]}{SPACE}{job[PUB_YEAR_STR]}'

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -81,24 +81,24 @@ def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int,
         messages.append(f'ERROR: Not enough arguments for date-spec in ({job[DATE_SPEC]})')
         return 2, messages
 
-    if len(day_str) != 2:
+    if len(job[PUB_DAY_STR]) != 2:
         print('ERROR: Day part must be two-digits (zero-padded)')
         return 2, messages
 
     try:
-        job[PUB_DAY_INT] = int(day_str)
+        job[PUB_DAY_INT] = int(job[PUB_DAY_STR])
         if not 1 <= job[PUB_DAY_INT] <= 31:
             raise ValueError
     except ValueError:
         print('ERROR: Day part must be an integral number in [1, 31]')
         return 2, messages
 
-    if month_name_en not in month_names:
-        print(f'ERROR: English month part must be in ({CSEP.join(month_names)})')
+    if job[PUB_MONTH_NAME_EN] not in MONTHS_EN:
+        print(f'ERROR: English month part must be in ({CSEP.join(MONTHS_EN)})')
         return 2, messages
 
     job[PUB_MONTH_STR] = '00'
-    for number, name in enumerate(month_names, start=1):
+    for number, name in enumerate(MONTHS_EN, start=1):
         if month_name_en == name:
             job[PUB_MONTH_STR] = f'{number :02d}'
 
@@ -113,7 +113,7 @@ def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int,
     now = dti.datetime.now(dti.UTC)
     this_year = now.year
     try:
-        job[PUB_YEAR_INT] = int(year_str)
+        job[PUB_YEAR_INT] = int(job[PUB_YEAR_STR])
         if job[PUB_YEAR_INT] < this_year - 1:
             raise ValueError
     except ValueError:

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -3,6 +3,7 @@
 import calendar as cal
 import datetime as dti
 import difflib
+import locale
 import pathlib
 import os
 import sys
@@ -22,21 +23,10 @@ SEMI = ';'
 SPACE = ' '
 CSEP = COMMA + SPACE
 TM = '™'
+LANG_CODE = 'en_US'
 
-MONTHS_EN = (
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-)
+locale.setlocale(locale.LC_ALL, LANG_CODE)
+MONTHS_EN = tuple(name for name in cal.month_name[1:])
 
 here = pathlib.Path().absolute()
 tool = pathlib.Path(__file__)

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -3,11 +3,17 @@
 import calendar as cal
 import datetime as dti
 import difflib
+import json
 import locale
 import pathlib
 import os
 import sys
 
+# Types
+Job = dict[str, bool | str | int]
+Messages = list[str]
+
+# General constants
 ENCODING = 'utf-8'
 ENC_ERRS = 'ignore'
 NL = '\n'
@@ -25,94 +31,177 @@ CSEP = COMMA + SPACE
 TM = '™'
 LANG_CODE = 'en_US'
 
+# Generate tuple with English month names in title case
 locale.setlocale(locale.LC_ALL, LANG_CODE)
 MONTHS_EN = tuple(name for name in cal.month_name[1:])
 
+# Harden the key based job user data interface
+COMMIT = 'commit'
+DEBUG = 'debug'
+DATE_SPEC = 'date-spec'
+
+# Harden the key based job derived data interface
+PUB_DAY_STR = 'pub-day-str'
+PUB_MONTH_NAME_EN = 'pub-month-name-en'
+PUB_YEAR_STR = 'pub-year-str'
+
+PUB_DAY_INT = 'pub-day-int'
+PUB_MONTH_STR = 'pub-month-en-str'
+PUB_MONTH_INT = 'pub-month-int'
+PUB_YEAR_INT = 'pub-year-int'
+
+PUB_DATE = 'pub-date'
+PUB_ISO_COMPACT = 'pub-iso-compact'
+PUB_ISO_DASH = 'pub-iso-dash'
+
+# Nicer usage info
 here = pathlib.Path().absolute()
 tool = pathlib.Path(__file__)
 path = tool.relative_to(here)
-usage = f'usage: {path} [--commit] "DD Month YYYY"'
+USAGE = f'usage: {path} [--{COMMIT}] [--{DEBUG}] "DD Month YYYY"'
+
+
+def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int, Job, Messages]:
+    """Parse (and validate) the given date-spec in the job into a multi format structure.
+
+    Note: Expected is format DD B YYYY, where B is the format-code for a title cased
+          English month name like January.
+    """
+    messages: Messages = []
+    try:
+        day_str, month_name_en, year_str = job[DATE_SPEC].split(SPACE)
+        job[PUB_DAY_STR] = day_str
+        month_name_en = month_name_en.title()
+        job[PUB_MONTH_NAME_EN] = month_name_en
+        job[PUB_YEAR_STR] = year_str
+    except ValueError:
+        messages.append(f'ERROR: Parsing date value ({job[DATE_SPEC]})')
+        return 2, messages
+    except IndexError:
+        messages.append(f'ERROR: Not enough arguments for date-spec in ({job[DATE_SPEC]})')
+        return 2, messages
+
+    if len(day_str) != 2:
+        print('ERROR: Day part must be two-digits (zero-padded)')
+        return 2, messages
+
+    try:
+        job[PUB_DAY_INT] = int(day_str)
+        if not 1 <= job[PUB_DAY_INT] <= 31:
+            raise ValueError
+    except ValueError:
+        print('ERROR: Day part must be an integral number in [1, 31]')
+        return 2, messages
+
+    if month_name_en not in month_names:
+        print(f'ERROR: English month part must be in ({CSEP.join(month_names)})')
+        return 2, messages
+
+    job[PUB_MONTH_STR] = '00'
+    for number, name in enumerate(month_names, start=1):
+        if month_name_en == name:
+            job[PUB_MONTH_STR] = f'{number :02d}'
+
+    if job[PUB_MONTH_STR] == '00':
+        print('ERROR: English month part to %m mapping failed')
+        return 1, messages
+
+    if len(year_str) != 4:
+        print('ERROR: Year part must be four-digits')
+        return 2, messages
+
+    now = dti.datetime.now(dti.UTC)
+    this_year = now.year
+    try:
+        job[PUB_YEAR_INT] = int(year_str)
+        if job[PUB_YEAR_INT] < this_year - 1:
+            raise ValueError
+    except ValueError:
+        print(f'ERROR: Year part must be an integral number >= {this_year - 1}')
+        return 2, messages
+
+    try:
+        job[PUB_MONTH_INT] = int(job[PUB_MONTH_STR])
+        if not 1 <= job[PUB_MONTH_INT] <= 12:
+            raise ValueError
+    except ValueError:
+        print('ERROR: Month part must map to an integral number in [1, 12]')
+        return 1, messages
+
+    _, max_days_of_month = cal.monthrange(job[PUB_YEAR_INT], job[PUB_MONTH_INT])
+    if job[PUB_DAY_INT] > max_days_of_month:
+        print(f'ERROR: Day part must be inside days of month [1, {max_days_of_month}]')
+        return 2, messages
+
+    job[PUB_DATE] = f'{job[PUB_DAY_STR]}{SPACE}{job[PUB_MONTH_NAME_EN]}{SPACE}{job[PUB_YEAR_STR]}'
+    job[PUB_ISO_DASH] = f'{job[PUB_YEAR_STR]}{DASH}{job[PUB_MONTH_STR]}{DASH}{job[PUB_DAY_STR]}'
+    job[PUB_ISO_COMPACT] = job[PUB_ISO_DASH].replace(DASH, '')
+
+    return 0, messages
+
+
+def parse_args(args: list[str]) -> tuple[int, Job, Messages]:
+    """Parse the given arguments returning an error code, the expected job structure, and messages."""
+    job: Job = {}
+    messages: Messages = []
+    if not args:
+        return 0, job, messages
+
+    job[DEBUG] = bool(os.getenv('BUMP_DEBUG', ''))
+    for slot, arg in enumerate(args):
+        if arg.lower() == f'--{DEBUG}':
+            job[DEBUG] = True
+            del args[slot]
+
+    job[COMMIT] = False
+    for slot, arg in enumerate(args):
+        if arg.lower() == f'--{COMMIT}':
+            job[COMMIT] = True
+            del args[slot]
+
+    job[DATE_SPEC] = ''
+    try:
+        slot = 0
+        job[DATE_SPEC] = args[slot].strip(SPACE)
+        del args[slot]
+    except IndexError:
+        messages.append('ERROR: Not enough arguments')
+        return 2, job, messages
+
+    if args:
+        messages.append('ERROR: Too many arguments')
+        return 2, job, messages
+
+    return 0, job, messages
 
 
 def main(args: list[str]) -> int:
     """Drive the transform to bump the dates based on the given argument."""
-    if not args:
-        print(usage)
-        sys.exit(0)
+    err, job, messages = parse_args(args)
 
-    commit = False
-    for slot, arg in enumerate(args):
-        if arg.lower() == '--commit':
-            commit = True
-            del args[slot]
+    if not err and not job:
+        print(USAGE)
+        return 0
 
-    try:
-        DD, Month, YYYY = args[0].split(SPACE)
-    except ValueError:
-        print(usage)
-        print(f'ERROR: Parsing date value ({args[0]})')
-        return 2
-    except IndexError:
-        print(usage)
-        print('ERROR: Not enough arguments')
+    if err:
+        print(USAGE)
+        for message in messages:
+            print(message)
         return 2
 
-    PUB_DAY = DD
-    PUB_MONTH_EN = Month.title()
-    PUB_YEAR = YYYY
+    err, messages = parse_date(job)
 
-    if len(PUB_DAY) != 2:
-        print('ERROR: Day part must be two-digits (zero-padded)')
+    if err:
+        print(USAGE)
+        for message in messages:
+            print(message)
         return 2
 
-    try:
-        d = int(PUB_DAY)
-        if not 1 <= d <= 31:
-            raise ValueError
-    except ValueError:
-        print('ERROR: Day part must be an integral number in [1, 31]')
-        return 2
-
-    if PUB_MONTH_EN not in MONTHS_EN:
-        print(f'ERROR: English month part must be in ({CSEP.join(MONTHS_EN)})')
-        return 2
-
-    PUB_MONTH = '00'
-    for number, name in enumerate(MONTHS_EN, start=1):
-        if PUB_MONTH_EN == name:
-            PUB_MONTH = f'{number :02d}'
-
-    if PUB_MONTH == '00':
-        print('ERROR: English month part to %m mapping failed')
-        return 1
-
-    if len(PUB_YEAR) != 4:
-        print('ERROR: Year part must be four-digits')
-        return 2
-
-    now = dti.datetime.now(dti.UTC)
-    this_year = now.year
-
-    try:
-        y = int(PUB_YEAR)
-        if y < this_year - 1:
-            raise ValueError
-    except ValueError:
-        print(f'ERROR: Year part must be an integral number >= {this_year - 1}')
-        return 2
-
-    try:
-        m = int(PUB_MONTH)
-        if not 1 <= m <= 12:
-            raise ValueError
-    except ValueError:
-        print('ERROR: Month part must map to an integral number in [1, 12]')
-        return 1
-
-    _, max_days_of_month = cal.monthrange(y, m)
-    if d > max_days_of_month:
-        print(f'ERROR: Day part must be inside days of month [1, {max_days_of_month}]')
-        return 2
+    commit = job[COMMIT]
+    debug = job[DEBUG]
+    if debug:
+        print('DEBUG: The job was parsed as follows:')
+        print(json.dumps(job, indent=2))
 
     if not commit:
         print('INFO: Dry-run only - only diffs are shown and no files changed.')
@@ -120,9 +209,6 @@ def main(args: list[str]) -> int:
     else:
         print('INFO: Commit mode - the magical five files will be bumped.')
         print()
-
-    PUB_DATE = f'{PUB_DAY} {PUB_MONTH_EN} {PUB_YEAR}'
-    DEBUG = bool(os.getenv('BUMP_DEBUG', ''))
 
     # Configuration and runtime parameter candidates:
     PDF_BOOKMATTER_IN = pathlib.Path('etc/liitos/bookmatter.tex.in')
@@ -137,15 +223,16 @@ def main(args: list[str]) -> int:
         lines = [line.rstrip(NL) for line in source.readlines()]
 
     bumped = []
+    debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
         prefix = r'\subsection*{'
         postfix = r'}\label{pub-date}'
         # \subsection*{21 January 2026}\label{pub-date}
         if line.startswith(prefix) and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
-            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-            bumped.append(prefix + PUB_DATE + postfix)
-            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + job[PUB_DATE] + postfix)
+            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
             continue
 
         prefix = 'Hagen, and Thomas Schmidt. '
@@ -153,9 +240,9 @@ def main(args: list[str]) -> int:
         # Hagen, and Thomas Schmidt. 21 January 2026. OASIS Committee Specification
         if line.startswith(prefix) and line.endswith('. OASIS Committee Specification'):
             pub_date = line.replace(prefix, '').replace('. OASIS Committee Specification', '')
-            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-            bumped.append(prefix + PUB_DATE + '. OASIS Committee Specification')
-            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + job[PUB_DATE] + '. OASIS Committee Specification')
+            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
             continue
 
         bumped.append(line)
@@ -181,15 +268,16 @@ def main(args: list[str]) -> int:
         lines = [line.rstrip(NL) for line in source.readlines()]
 
     bumped = []
+    debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
         #     footer_outer_field_normal_pages: 21 January 2026 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
         prefix = '    footer_outer_field_normal_pages: '
         postfix = r' - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}'
         if line.startswith(prefix) and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
-            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-            bumped.append(prefix + PUB_DATE + postfix)
-            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + job[PUB_DATE] + postfix)
+            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
             continue
 
         bumped.append(line)
@@ -216,15 +304,16 @@ def main(args: list[str]) -> int:
         lines = [line.rstrip(NL) for line in source.readlines()]
 
     bumped = []
+    debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
         prefix = r'  \cfoot*{\upshape{\scriptsize Copyright © OASIS Open '
         postfix = r'. All Rights Reserved.}}'
         #   \cfoot*{\upshape{\scriptsize Copyright © OASIS Open 2026. All Rights Reserved.}}
         if line.startswith(prefix) and line.endswith(postfix):
             copyright_year = line.replace(prefix, '').replace(postfix, '')
-            DEBUG and print(f'DEBUG: Found prior copyright-year ({copyright_year})')
-            bumped.append(prefix + PUB_YEAR + postfix)
-            DEBUG and print(f'DEBUG: Bumped to ({PUB_YEAR})')
+            debug and print(f'DEBUG: Found prior copyright-year ({copyright_year})')
+            bumped.append(prefix + job[PUB_YEAR_STR] + postfix)
+            debug and print(f'DEBUG: Bumped to ({job[PUB_YEAR_STR]})')
             continue
 
         bumped.append(line)
@@ -252,6 +341,7 @@ def main(args: list[str]) -> int:
         lines = [line.rstrip(NL) for line in source.readlines()]
 
     bumped = []
+    debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
         # ## 21 January 2026
         prefix = '## '
@@ -261,9 +351,9 @@ def main(args: list[str]) -> int:
                 day = line.replace(prefix, '').replace(postfix, '').split(SPACE)[0]
                 int(day)
                 pub_date = line.replace(prefix, '').replace(postfix, '')
-                DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-                bumped.append(prefix + PUB_DATE + postfix)
-                DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+                debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
+                bumped.append(prefix + job[PUB_DATE] + postfix)
+                debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
                 continue
             except ValueError:
                 pass
@@ -274,13 +364,13 @@ def main(args: list[str]) -> int:
         if 11 < len(line) < 19 and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
             try:
-                a_day, a_month_name, a_year = pub_date.split(SPACE)
+                a_day, a_month_name, a_year = pub_date.split(SPACE)  # noqa
             except (ValueError, IndexError):
                 bumped.append(line)
                 continue
-            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-            bumped.append(prefix + PUB_DATE + postfix)
-            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + job[PUB_DATE] + postfix)
+            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
             continue
 
         # Copyright &copy; OASIS Open 2026. All Rights Reserved.
@@ -288,9 +378,9 @@ def main(args: list[str]) -> int:
         postfix = '. All Rights Reserved.'
         if line.startswith(prefix) and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
-            DEBUG and print(f'DEBUG: Found prior pub-date ({pub_date})')
-            bumped.append(prefix + PUB_YEAR + postfix)
-            DEBUG and print(f'DEBUG: Bumped to ({PUB_DATE})')
+            debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
+            bumped.append(prefix + job[PUB_YEAR_STR] + postfix)
+            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
             continue
 
         bumped.append(line)
@@ -321,9 +411,10 @@ def main(args: list[str]) -> int:
     past_table = None  # State machine: None -> False -> True -> None
     trigger_prefix = '|:-----------------------------'
     prefix = '| eox-core-v1.0-wd'
-    in_between = f'{PUB_YEAR}{PUB_MONTH}{PUB_DAY}-dev | {PUB_YEAR}-{PUB_MONTH}-{PUB_DAY}'
+    in_between = f'{job[PUB_ISO_COMPACT]}-dev | {job[PUB_ISO_DASH]}'
     stop_token = prefix + in_between
     postfix = ' | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |'
+    debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
         # | eox-core-v1.0-wd20260121-dev | 2026-01-21 | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |
         # <-- append here when past_table is True
@@ -339,13 +430,13 @@ def main(args: list[str]) -> int:
             continue
 
         if not line.strip(SPACE + DASH) and past_table is False:
-            DEBUG and print('DEBUG: Found empty line following revision history table')
+            debug and print('DEBUG: Found empty line following revision history table')
             if do_amend:
                 bumped.append(prefix + in_between + postfix)
-                DEBUG and print(f'DEBUG: Appended with in_between ({in_between})')
+                debug and print(f'DEBUG: Appended with in_between ({in_between})')
                 do_amend = False
             else:
-                DEBUG and print(f'DEBUG: Did NOT append duplicate ({in_between})')
+                debug and print(f'DEBUG: Did NOT append duplicate ({in_between})')
             bumped.append(line)
             continue
 

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -93,12 +93,12 @@ def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int,
         print('ERROR: Day part must be an integral number in [1, 31]')
         return 2, messages
 
-    if job[PUB_MONTH_NAME_EN] not in MONTHS_EN:
-        print(f'ERROR: English month part must be in ({CSEP.join(MONTHS_EN)})')
+    if job[PUB_MONTH_NAME_EN] not in month_names:
+        print(f'ERROR: English month part must be in ({CSEP.join(month_names)})')
         return 2, messages
 
     job[PUB_MONTH_STR] = '00'
-    for number, name in enumerate(MONTHS_EN, start=1):
+    for number, name in enumerate(month_names, start=1):
         if month_name_en == name:
             job[PUB_MONTH_STR] = f'{number :02d}'
 
@@ -181,13 +181,13 @@ def main(args: list[str]) -> int:
 
     if not err and not job:
         print(USAGE)
-        return 0
+        return err
 
     if err:
         print(USAGE)
         for message in messages:
             print(message)
-        return 2
+        return err
 
     err, messages = parse_date(job)
 
@@ -195,7 +195,7 @@ def main(args: list[str]) -> int:
         print(USAGE)
         for message in messages:
             print(message)
-        return 2
+        return err
 
     commit = job[COMMIT]
     debug = job[DEBUG]

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -62,6 +62,7 @@ PREFIX = 'prefix'
 POSTFIX = 'postfix'
 OPERATOR = 'operator'
 TOKEN = 'token'
+REPLACEMENT_CODE = 'replacement-code'
 
 # Nicer usage info
 here = pathlib.Path().absolute()
@@ -75,6 +76,59 @@ PDF_META_YAML = pathlib.Path('etc/liitos/meta.yml')
 PDF_SETUP_IN = pathlib.Path('etc/liitos/setup.tex.in')
 SRC_FRONTMATTER = pathlib.Path('src/frontmatter.md')
 SRC_HISTORY = pathlib.Path('src/revision-history.md')
+
+SIMPLE_TRANSFORMS = {
+    PDF_BOOKMATTER_IN:[
+        {
+            PREFIX: {
+                TOKEN: '\\subsection*{',
+                OPERATOR: 'startswith',
+            },
+            REPLACEMENT_CODE: PUB_DATE,
+            POSTFIX: {
+                TOKEN: '}\\label{pub-date}',
+                OPERATOR: 'endswith',
+            },
+        },
+        {
+            PREFIX: {
+                TOKEN: 'Hagen, and Thomas Schmidt. ',
+                OPERATOR: 'startswith',
+            },
+            REPLACEMENT_CODE: PUB_DATE,
+            POSTFIX: {
+                TOKEN: '. OASIS Committee Specification',
+                OPERATOR: 'endswith',
+            },
+        },
+    ],
+    PDF_META_YAML: [
+        {
+            PREFIX: {
+                TOKEN: '    footer_outer_field_normal_pages: ',
+                OPERATOR: 'startswith',
+            },
+            REPLACEMENT_CODE: PUB_DATE,
+            POSTFIX: {
+                TOKEN: ' - \\theMetaPageNumPrefix { } \\thepage { } of \\pageref{LastPage}',
+                OPERATOR: 'endswith',
+            },
+        },
+    ],
+    PDF_SETUP_IN: [
+        {
+            PREFIX: {
+                TOKEN: '  \\cfoot*{\\upshape{\\scriptsize Copyright © OASIS Open ',
+                OPERATOR: 'startswith',
+            },
+            REPLACEMENT_CODE: PUB_YEAR_STR,
+            POSTFIX: {
+                TOKEN: '. All Rights Reserved.}}',
+                OPERATOR: 'endswith',
+            },
+        },
+    ],
+}
 
 
 def parse_date_spec(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int, Job, Messages]:
@@ -232,28 +286,34 @@ def apply_simple_changes(
     file_path: PathLike,
     old: list[str],
     transforms: Transforms,
-    replacements: Replacements,
-    we_debug: bool
+    job: Job,
 ) -> tuple[int, list[str]]:
     """Apply the transforms and replacements to old in simple cases and return error code and new.
 
     Note: when error code not zero, than new contains not the transformed data but a list of messages"""
+    if file_path not in transforms:
+        msg = f'ERROR: [{file_path}] not in keys ({COMMA.join(transforms)}) of transforms map'
+        return 2, [msg]
+    we_debug = job.get(DEBUG, False)
     if we_debug:
         print('#  -  -  -  -  -  -  -  -  - ')
         print(f'DEBUG: [{file_path}] Applying transforms:')
-        print(json.dumps(transforms, indent=2))
-        print(f'DEBUG: [{file_path}] Using replacements:')
-        print(json.dumps(replacements, indent=2))
+        print(json.dumps(transforms[file_path], indent=2))
     new = []
     for line in old:
         applied = False
-        for transform, replacement in zip(transforms, replacements):
+        for transform in transforms[file_path]:
 
             pre_tok = transform[PREFIX][TOKEN]
             op_str = transform[PREFIX][OPERATOR]
             pre_op = getattr(line, op_str, None)
             if pre_op is None:
                 msg = f'ERROR: [{file_path}] unexpected prefix matching operator {op_str}'
+                return 2, [msg]
+
+            replacement = job.get(transform[REPLACEMENT_CODE], None)
+            if replacement is None:
+                msg = f'ERROR: [{file_path}] replacement code ({transform[REPLACEMENT_CODE]}) not known'
                 return 2, [msg]
 
             post_tok = transform[POSTFIX][TOKEN]
@@ -314,33 +374,7 @@ def main(args: list[str]) -> int:
     any_changes = False
 
     lines = load_target(PDF_BOOKMATTER_IN)
-    transforms = [
-        {
-            PREFIX: {
-                TOKEN: '\\subsection*{',
-                OPERATOR: 'startswith',
-            },
-            POSTFIX: {
-                TOKEN: '}\\label{pub-date}',
-                OPERATOR: 'endswith',
-            },
-        },
-        {
-            PREFIX: {
-                TOKEN: 'Hagen, and Thomas Schmidt. ',
-                OPERATOR: 'startswith',
-            },
-            POSTFIX: {
-                TOKEN: '. OASIS Committee Specification',
-                OPERATOR: 'endswith',
-            },
-        },
-    ]
-    replacements = [
-        job[PUB_DATE],
-        job[PUB_DATE],
-    ]
-    err, bumped = apply_simple_changes(PDF_BOOKMATTER_IN, lines, transforms, replacements, debug)
+    err, bumped = apply_simple_changes(PDF_BOOKMATTER_IN, lines, SIMPLE_TRANSFORMS, job)
     if err:
         for message in messages:
             print(message)
@@ -348,22 +382,7 @@ def main(args: list[str]) -> int:
     any_changes = output(PDF_BOOKMATTER_IN, lines, bumped, any_changes, do_commit)
 
     lines = load_target(PDF_META_YAML)
-    transforms = [
-        {
-            PREFIX: {
-                TOKEN: '    footer_outer_field_normal_pages: ',
-                OPERATOR: 'startswith',
-            },
-            POSTFIX: {
-                TOKEN: ' - \\theMetaPageNumPrefix { } \\thepage { } of \\pageref{LastPage}',
-                OPERATOR: 'endswith',
-            },
-        },
-    ]
-    replacements = [
-        job[PUB_DATE],
-    ]
-    err, bumped = apply_simple_changes(PDF_META_YAML, lines, transforms, replacements, debug)
+    err, bumped = apply_simple_changes(PDF_META_YAML, lines, SIMPLE_TRANSFORMS, job)
     if err:
         for message in messages:
             print(message)
@@ -371,22 +390,7 @@ def main(args: list[str]) -> int:
     any_changes = output(PDF_META_YAML, lines, bumped, any_changes, do_commit)
 
     lines = load_target(PDF_SETUP_IN)
-    transforms = [
-        {
-            PREFIX: {
-                TOKEN: '  \\cfoot*{\\upshape{\\scriptsize Copyright © OASIS Open ',
-                OPERATOR: 'startswith',
-            },
-            POSTFIX: {
-                TOKEN: '. All Rights Reserved.}}',
-                OPERATOR: 'endswith',
-            },
-        },
-    ]
-    replacements = [
-        job[PUB_YEAR_STR],
-    ]
-    err, bumped = apply_simple_changes(PDF_SETUP_IN, lines, transforms, replacements, debug)
+    err, bumped = apply_simple_changes(PDF_SETUP_IN, lines, SIMPLE_TRANSFORMS, job)
     if err:
         for message in messages:
             print(message)

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -13,6 +13,8 @@ import sys
 Job = dict[str, bool | str | int]
 Messages = list[str]
 PathLike = str | pathlib.Path
+Replacements = list[str]
+Transforms = list[dict[str, dict[str]]]
 
 # General constants
 ENCODING = 'utf-8'
@@ -54,6 +56,12 @@ PUB_YEAR_INT = 'pub-year-int'
 PUB_DATE = 'pub-date'
 PUB_ISO_COMPACT = 'pub-iso-compact'
 PUB_ISO_DASH = 'pub-iso-dash'
+
+# Transform keys
+PREFIX = 'prefix'
+POSTFIX = 'postfix'
+OPERATOR = 'operator'
+TOKEN = 'token'
 
 # Nicer usage info
 here = pathlib.Path().absolute()
@@ -220,6 +228,54 @@ def load_target(file_path: PathLike) -> list[str]:
         return [line.rstrip(NL) for line in source.readlines()]
 
 
+def apply_simple_changes(
+    file_path: PathLike,
+    old: list[str],
+    transforms: Transforms,
+    replacements: Replacements,
+    we_debug: bool
+) -> tuple[int, list[str]]:
+    """Apply the transforms and replacements to old in simple cases and return error code and new.
+
+    Note: when error code not zero, than new contains not the transformed data but a list of messages"""
+    if we_debug:
+        print('#  -  -  -  -  -  -  -  -  - ')
+        print(f'DEBUG: [{file_path}] Applying transforms:')
+        print(json.dumps(transforms, indent=2))
+        print(f'DEBUG: [{file_path}] Using replacements:')
+        print(json.dumps(replacements, indent=2))
+    new = []
+    for line in old:
+        applied = False
+        for transform, replacement in zip(transforms, replacements):
+
+            pre_tok = transform[PREFIX][TOKEN]
+            op_str = transform[PREFIX][OPERATOR]
+            pre_op = getattr(line, op_str, None)
+            if pre_op is None:
+                msg = f'ERROR: [{file_path}] unexpected prefix matching operator {op_str}'
+                return 2, [msg]
+
+            post_tok = transform[POSTFIX][TOKEN]
+            op_str = transform[POSTFIX][OPERATOR]
+            post_op = getattr(line, op_str, None)
+            if post_op is None:
+                msg = f'ERROR: [{file_path}] unexpected postfix matching operator {op_str}'
+                return 2, [msg]
+
+            if pre_op(pre_tok) and post_op(post_tok):
+                value = line.replace(pre_tok, '').replace(post_tok, '')
+                we_debug and print(f'DEBUG: Found prior value ({value})')
+                new.append(pre_tok + replacement + post_tok)
+                we_debug and print(f'DEBUG: Replaced with ({replacement})')
+                applied = True
+
+        if not applied:
+            new.append(line)
+
+    return 0, new
+
+
 def main(args: list[str]) -> int:
     """Drive the transform to bump the dates based on the given argument."""
     err, job, messages = parse_args(args)
@@ -258,63 +314,83 @@ def main(args: list[str]) -> int:
     any_changes = False
 
     lines = load_target(PDF_BOOKMATTER_IN)
-    bumped = []
-    debug and print('#  -  -  -  -  -  -  -  -  - ')
-    for line in lines:
-        prefix = '\\subsection*{'
-        postfix = '}\\label{pub-date}'
-        if line.startswith(prefix) and line.endswith(postfix):
-            pub_date = line.replace(prefix, '').replace(postfix, '')
-            debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
-            bumped.append(prefix + job[PUB_DATE] + postfix)
-            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
-            continue
-
-        prefix = 'Hagen, and Thomas Schmidt. '
-        postfix = '. OASIS Committee Specification'
-        if line.startswith(prefix) and line.endswith(postfix):
-            pub_date = line.replace(prefix, '').replace(postfix, '')
-            debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
-            bumped.append(prefix + job[PUB_DATE] + '. OASIS Committee Specification')
-            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
-            continue
-
-        bumped.append(line)
-
+    transforms = [
+        {
+            PREFIX: {
+                TOKEN: '\\subsection*{',
+                OPERATOR: 'startswith',
+            },
+            POSTFIX: {
+                TOKEN: '}\\label{pub-date}',
+                OPERATOR: 'endswith',
+            },
+        },
+        {
+            PREFIX: {
+                TOKEN: 'Hagen, and Thomas Schmidt. ',
+                OPERATOR: 'startswith',
+            },
+            POSTFIX: {
+                TOKEN: '. OASIS Committee Specification',
+                OPERATOR: 'endswith',
+            },
+        },
+    ]
+    replacements = [
+        job[PUB_DATE],
+        job[PUB_DATE],
+    ]
+    err, bumped = apply_simple_changes(PDF_BOOKMATTER_IN, lines, transforms, replacements, debug)
+    if err:
+        for message in messages:
+            print(message)
+        return err
     any_changes = output(PDF_BOOKMATTER_IN, lines, bumped, any_changes, do_commit)
 
     lines = load_target(PDF_META_YAML)
-    bumped = []
-    debug and print('#  -  -  -  -  -  -  -  -  - ')
-    for line in lines:
-        prefix = '    footer_outer_field_normal_pages: '
-        postfix = ' - \\theMetaPageNumPrefix { } \\thepage { } of \\pageref{LastPage}'
-        if line.startswith(prefix) and line.endswith(postfix):
-            pub_date = line.replace(prefix, '').replace(postfix, '')
-            debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
-            bumped.append(prefix + job[PUB_DATE] + postfix)
-            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
-            continue
-
-        bumped.append(line)
-
+    transforms = [
+        {
+            PREFIX: {
+                TOKEN: '    footer_outer_field_normal_pages: ',
+                OPERATOR: 'startswith',
+            },
+            POSTFIX: {
+                TOKEN: ' - \\theMetaPageNumPrefix { } \\thepage { } of \\pageref{LastPage}',
+                OPERATOR: 'endswith',
+            },
+        },
+    ]
+    replacements = [
+        job[PUB_DATE],
+    ]
+    err, bumped = apply_simple_changes(PDF_META_YAML, lines, transforms, replacements, debug)
+    if err:
+        for message in messages:
+            print(message)
+        return err
     any_changes = output(PDF_META_YAML, lines, bumped, any_changes, do_commit)
 
     lines = load_target(PDF_SETUP_IN)
-    bumped = []
-    debug and print('#  -  -  -  -  -  -  -  -  - ')
-    for line in lines:
-        prefix = '  \\cfoot*{\\upshape{\\scriptsize Copyright © OASIS Open '
-        postfix = '. All Rights Reserved.}}'
-        if line.startswith(prefix) and line.endswith(postfix):
-            copyright_year = line.replace(prefix, '').replace(postfix, '')
-            debug and print(f'DEBUG: Found prior copyright-year ({copyright_year})')
-            bumped.append(prefix + job[PUB_YEAR_STR] + postfix)
-            debug and print(f'DEBUG: Bumped to ({job[PUB_YEAR_STR]})')
-            continue
-
-        bumped.append(line)
-
+    transforms = [
+        {
+            PREFIX: {
+                TOKEN: '  \\cfoot*{\\upshape{\\scriptsize Copyright © OASIS Open ',
+                OPERATOR: 'startswith',
+            },
+            POSTFIX: {
+                TOKEN: '. All Rights Reserved.}}',
+                OPERATOR: 'endswith',
+            },
+        },
+    ]
+    replacements = [
+        job[PUB_YEAR_STR],
+    ]
+    err, bumped = apply_simple_changes(PDF_SETUP_IN, lines, transforms, replacements, debug)
+    if err:
+        for message in messages:
+            print(message)
+        return err
     any_changes = output(PDF_SETUP_IN, lines, bumped, any_changes, do_commit)
 
     lines = load_target(SRC_FRONTMATTER)
@@ -330,7 +406,7 @@ def main(args: list[str]) -> int:
                 pub_date = line.replace(prefix, '').replace(postfix, '')
                 debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
                 bumped.append(prefix + job[PUB_DATE] + postfix)
-                debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
+                debug and print(f'DEBUG: Replaced with ({job[PUB_DATE]})')
                 continue
             except ValueError:
                 pass
@@ -346,7 +422,7 @@ def main(args: list[str]) -> int:
                 continue
             debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
             bumped.append(prefix + job[PUB_DATE] + postfix)
-            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
+            debug and print(f'DEBUG: Replaced with ({job[PUB_DATE]})')
             continue
 
         prefix = 'Copyright &copy; OASIS Open '
@@ -355,7 +431,7 @@ def main(args: list[str]) -> int:
             pub_date = line.replace(prefix, '').replace(postfix, '')
             debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
             bumped.append(prefix + job[PUB_YEAR_STR] + postfix)
-            debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
+            debug and print(f'DEBUG: Replaced with ({job[PUB_DATE]})')
             continue
 
         bumped.append(line)

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -262,8 +262,8 @@ def main(args: list[str]) -> int:
         prefix = 'Hagen, and Thomas Schmidt. '
         postfix = '. OASIS Committee Specification'
         # Hagen, and Thomas Schmidt. 21 January 2026. OASIS Committee Specification
-        if line.startswith(prefix) and line.endswith('. OASIS Committee Specification'):
-            pub_date = line.replace(prefix, '').replace('. OASIS Committee Specification', '')
+        if line.startswith(prefix) and line.endswith(postfix):
+            pub_date = line.replace(prefix, '').replace(postfix, '')
             debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
             bumped.append(prefix + job[PUB_DATE] + '. OASIS Committee Specification')
             debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -61,7 +61,7 @@ path = tool.relative_to(here)
 USAGE = f'usage: {path} [--{COMMIT}] [--{DEBUG}] "DD Month YYYY"'
 
 
-def parse_date(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int, Job, Messages]:
+def parse_date_spec(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int, Job, Messages]:
     """Parse (and validate) the given date-spec in the job into a multi format structure.
 
     Note: Expected is format DD B YYYY, where B is the format-code for a title cased
@@ -189,7 +189,7 @@ def main(args: list[str]) -> int:
             print(message)
         return err
 
-    err, messages = parse_date(job)
+    err, messages = parse_date_spec(job)
 
     if err:
         print(USAGE)

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -61,6 +61,13 @@ tool = pathlib.Path(__file__)
 path = tool.relative_to(here)
 USAGE = f'usage: {path} [--{COMMIT}] [--{DEBUG}] "DD Month YYYY"'
 
+# Configuration and runtime parameter candidates:
+PDF_BOOKMATTER_IN = pathlib.Path('etc/liitos/bookmatter.tex.in')
+PDF_META_YAML = pathlib.Path('etc/liitos/meta.yml')
+PDF_SETUP_IN = pathlib.Path('etc/liitos/setup.tex.in')
+SRC_FRONTMATTER = pathlib.Path('src/frontmatter.md')
+SRC_HISTORY = pathlib.Path('src/revision-history.md')
+
 
 def parse_date_spec(job: Job, month_names: tuple[str, ...] = MONTHS_EN) -> tuple[int, Job, Messages]:
     """Parse (and validate) the given date-spec in the job into a multi format structure.
@@ -176,6 +183,15 @@ def parse_args(args: list[str]) -> tuple[int, Job, Messages]:
     return 0, job, messages
 
 
+def dump_target(file_path: PathLike, lines: list[str]) -> None:
+    """Dump the newline joined lines to the target text file path.
+
+    Note: a trailing newline is appended for POSIX conformance.
+    """
+    with open(file_path, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
+        target.write(NL.join(lines) + NL)
+
+
 def output(file_path: PathLike, old: list[str], new: list[str], changes_detected: bool, do_commit: bool) -> bool:
     """Show change state, diff if applicable, dump to path if do-commit, and return chained change state."""
     if old != new:
@@ -191,12 +207,17 @@ def output(file_path: PathLike, old: list[str], new: list[str], changes_detected
             tofile=f'{file_path}(new)',
         ))
         if do_commit:
-            with open(file_path, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-                target.write(NL.join(new) + NL)
+            dump_target(file_path, new)
     else:
         print(f'INFO: No changes to {file_path}')
 
     return changes_detected
+
+
+def load_target(file_path: PathLike) -> list[str]:
+    """Load the target text from file path and return the list of newline stripped lines."""
+    with open(file_path, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
+        return [line.rstrip(NL) for line in source.readlines()]
 
 
 def main(args: list[str]) -> int:
@@ -234,18 +255,9 @@ def main(args: list[str]) -> int:
         print('INFO: Commit mode - the magical five files will be bumped.')
         print()
 
-    # Configuration and runtime parameter candidates:
-    PDF_BOOKMATTER_IN = pathlib.Path('etc/liitos/bookmatter.tex.in')
-    PDF_META_YAML = pathlib.Path('etc/liitos/meta.yml')
-    PDF_SETUP_IN = pathlib.Path('etc/liitos/setup.tex.in')
-    SRC_FRONTMATTER = pathlib.Path('src/frontmatter.md')
-    SRC_HISTORY = pathlib.Path('src/revision-history.md')
-
     any_changes = False
 
-    with open(PDF_BOOKMATTER_IN, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-        lines = [line.rstrip(NL) for line in source.readlines()]
-
+    lines = load_target(PDF_BOOKMATTER_IN)
     bumped = []
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
@@ -271,9 +283,7 @@ def main(args: list[str]) -> int:
 
     any_changes = output(PDF_BOOKMATTER_IN, lines, bumped, any_changes, do_commit)
 
-    with open(PDF_META_YAML, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-        lines = [line.rstrip(NL) for line in source.readlines()]
-
+    lines = load_target(PDF_META_YAML)
     bumped = []
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
@@ -290,9 +300,7 @@ def main(args: list[str]) -> int:
 
     any_changes = output(PDF_META_YAML, lines, bumped, any_changes, do_commit)
 
-    with open(PDF_SETUP_IN, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-        lines = [line.rstrip(NL) for line in source.readlines()]
-
+    lines = load_target(PDF_SETUP_IN)
     bumped = []
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
@@ -309,9 +317,7 @@ def main(args: list[str]) -> int:
 
     any_changes = output(PDF_SETUP_IN, lines, bumped, any_changes, do_commit)
 
-    with open(SRC_FRONTMATTER, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-        lines = [line.rstrip(NL) for line in source.readlines()]
-
+    lines = load_target(SRC_FRONTMATTER)
     bumped = []
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
@@ -356,9 +362,7 @@ def main(args: list[str]) -> int:
 
     any_changes = output(SRC_FRONTMATTER, lines, bumped, any_changes, do_commit)
 
-    with open(SRC_HISTORY, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
-        lines = [line.rstrip(NL) for line in source.readlines()]
-
+    lines = load_target(SRC_HISTORY)
     bumped = []
     do_amend = True
     past_table = None  # State machine: None -> False -> True -> None

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -12,6 +12,7 @@ import sys
 # Types
 Job = dict[str, bool | str | int]
 Messages = list[str]
+PathLike = str | pathlib.Path
 
 # General constants
 ENCODING = 'utf-8'
@@ -175,6 +176,29 @@ def parse_args(args: list[str]) -> tuple[int, Job, Messages]:
     return 0, job, messages
 
 
+def output(file_path: PathLike, old: list[str], new: list[str], changes_detected: bool, do_commit: bool) -> bool:
+    """Show change state, diff if applicable, dump to path if do-commit, and return chained change state."""
+    if old != new:
+        if not changes_detected:
+            changes_detected = True
+        print()
+        print(f'# - - - 8< - -(( {file_path} )) - - - - - - - - - - - - - - - - - - >')
+        print()
+        sys.stdout.writelines(difflib.unified_diff(
+            tuple(line + NL for line in old),
+            tuple(line + NL for line in new),
+            fromfile=f'{file_path}(old)',
+            tofile=f'{file_path}(new)',
+        ))
+        if do_commit:
+            with open(file_path, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
+                target.write(NL.join(new) + NL)
+    else:
+        print(f'INFO: No changes to {file_path}')
+
+    return changes_detected
+
+
 def main(args: list[str]) -> int:
     """Drive the transform to bump the dates based on the given argument."""
     err, job, messages = parse_args(args)
@@ -197,13 +221,13 @@ def main(args: list[str]) -> int:
             print(message)
         return err
 
-    commit = job[COMMIT]
+    do_commit = job[COMMIT]
     debug = job[DEBUG]
     if debug:
         print('DEBUG: The job was parsed as follows:')
         print(json.dumps(job, indent=2))
 
-    if not commit:
+    if not do_commit:
         print('INFO: Dry-run only - only diffs are shown and no files changed.')
         print()
     else:
@@ -247,22 +271,7 @@ def main(args: list[str]) -> int:
 
         bumped.append(line)
 
-    if lines != bumped:
-        if not any_changes:
-            any_changes = True
-        print(f'# - - - 8< - -(( {PDF_BOOKMATTER_IN} )) - - - - - - - - - - - - - - >')
-        print()
-        sys.stdout.writelines(difflib.unified_diff(
-            tuple(line + NL for line in lines),
-            tuple(line + NL for line in bumped),
-            fromfile='bookmatter.tex.in',
-            tofile='bookmatter-bumped.tex.in',
-        ))
-        if commit:
-            with open(PDF_BOOKMATTER_IN, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-                target.write(NL.join(bumped) + NL)
-    else:
-        print(f'INFO: No changes to {PDF_BOOKMATTER_IN}')
+    any_changes = output(PDF_BOOKMATTER_IN, lines, bumped, any_changes, do_commit)
 
     with open(PDF_META_YAML, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
         lines = [line.rstrip(NL) for line in source.readlines()]
@@ -282,23 +291,7 @@ def main(args: list[str]) -> int:
 
         bumped.append(line)
 
-    if lines != bumped:
-        if not any_changes:
-            any_changes = True
-        print()
-        print(f'# - - - 8< - -(( {PDF_META_YAML} )) - - - - - - - - - - - - - - - - - - >')
-        print()
-        sys.stdout.writelines(difflib.unified_diff(
-            tuple(line + NL for line in lines),
-            tuple(line + NL for line in bumped),
-            fromfile='meta.yml',
-            tofile='meta-bumped.yml',
-        ))
-        if commit:
-            with open(PDF_META_YAML, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-                target.write(NL.join(bumped) + NL)
-    else:
-        print(f'INFO: No changes to {PDF_META_YAML}')
+    any_changes = output(PDF_META_YAML, lines, bumped, any_changes, do_commit)
 
     with open(PDF_SETUP_IN, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
         lines = [line.rstrip(NL) for line in source.readlines()]
@@ -318,24 +311,7 @@ def main(args: list[str]) -> int:
 
         bumped.append(line)
 
-    if lines != bumped:
-        if not any_changes:
-            any_changes = True
-        print()
-        print(f'# - - - 8< - -(( {PDF_SETUP_IN} )) - - - - - - - - - - - - - - >')
-        print()
-        sys.stdout.writelines(difflib.unified_diff(
-            tuple(line + NL for line in lines),
-            tuple(line + NL for line in bumped),
-            fromfile='setup.tex.in',
-            tofile='setup-bumped.tex.in',
-        ))
-        if commit:
-            with open(PDF_SETUP_IN, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-                target.write(NL.join(bumped) + NL)
-    else:
-        print(f'INFO: No changes to {PDF_SETUP_IN}')
-
+    any_changes = output(PDF_SETUP_IN, lines, bumped, any_changes, do_commit)
 
     with open(SRC_FRONTMATTER, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
         lines = [line.rstrip(NL) for line in source.readlines()]
@@ -385,23 +361,7 @@ def main(args: list[str]) -> int:
 
         bumped.append(line)
 
-    if lines != bumped:
-        if not any_changes:
-            any_changes = True
-        print()
-        print(f'# - - - 8< - -(( {SRC_FRONTMATTER} )) - - - - - - - - - - - - - - - - - - >')
-        print()
-        sys.stdout.writelines(difflib.unified_diff(
-            tuple(line + NL for line in lines),
-            tuple(line + NL for line in bumped),
-            fromfile='frontmatter.md',
-            tofile='frontmatter-bumped.md',
-        ))
-        if commit:
-            with open(SRC_FRONTMATTER, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-                target.write(NL.join(bumped) + NL)
-    else:
-        print(f'INFO: No changes to {SRC_FRONTMATTER}')
+    any_changes = output(SRC_FRONTMATTER, lines, bumped, any_changes, do_commit)
 
     with open(SRC_HISTORY, 'rt', encoding=ENCODING, errors=ENC_ERRS) as source:
         lines = [line.rstrip(NL) for line in source.readlines()]
@@ -442,30 +402,13 @@ def main(args: list[str]) -> int:
 
         bumped.append(line)
 
-    if lines != bumped:
-        if not any_changes:
-            any_changes = True
-        print()
-        print(f'# - - - 8< - -(( {SRC_HISTORY} )) - - - - - - - - - - - - - - - - - - >')
-        print()
-        sys.stdout.writelines(difflib.unified_diff(
-            tuple(line + NL for line in lines),
-            tuple(line + NL for line in bumped),
-            fromfile='revision-history.md',
-            tofile='revision-history-bumped.md',
-        ))
-        if commit:
-            with open(SRC_HISTORY, 'wt', encoding=ENCODING, errors=ENC_ERRS) as target:
-                target.write(NL.join(bumped) + NL)
-            print()
-    else:
-        print(f'INFO: No changes to {SRC_HISTORY}')
+    any_changes = output(SRC_HISTORY, lines, bumped, any_changes, do_commit)
 
     print()
     if any_changes:
-        print('INFO: Bumped - OK') if commit else print('INFO: Dry-Bumped - OK')
+        print('INFO: Bumped - OK') if do_commit else print('INFO: Dry-Bumped - OK')
     else:
-        print('INFO: No changes - no commit - OK') if commit else print('INFO: No dry-changes - nothing would be committed - OK')
+        print('INFO: No changes - no commit - OK') if do_commit else print('INFO: No dry-changes - nothing would be committed - OK')
 
     return 0
 

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -225,8 +225,8 @@ def main(args: list[str]) -> int:
     bumped = []
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
-        prefix = r'\subsection*{'
-        postfix = r'}\label{pub-date}'
+        prefix = '\\subsection*{'
+        postfix = '}\\label{pub-date}'
         # \subsection*{21 January 2026}\label{pub-date}
         if line.startswith(prefix) and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
@@ -272,7 +272,7 @@ def main(args: list[str]) -> int:
     for line in lines:
         #     footer_outer_field_normal_pages: 21 January 2026 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
         prefix = '    footer_outer_field_normal_pages: '
-        postfix = r' - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}'
+        postfix = ' - \\theMetaPageNumPrefix { } \\thepage { } of \\pageref{LastPage}'
         if line.startswith(prefix) and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
             debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
@@ -306,8 +306,8 @@ def main(args: list[str]) -> int:
     bumped = []
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
-        prefix = r'  \cfoot*{\upshape{\scriptsize Copyright © OASIS Open '
-        postfix = r'. All Rights Reserved.}}'
+        prefix = '  \\cfoot*{\\upshape{\\scriptsize Copyright © OASIS Open '
+        postfix = '. All Rights Reserved.}}'
         #   \cfoot*{\upshape{\scriptsize Copyright © OASIS Open 2026. All Rights Reserved.}}
         if line.startswith(prefix) and line.endswith(postfix):
             copyright_year = line.replace(prefix, '').replace(postfix, '')

--- a/eox-core-v-1-0/prose/edit/bin/bump.py
+++ b/eox-core-v-1-0/prose/edit/bin/bump.py
@@ -251,7 +251,6 @@ def main(args: list[str]) -> int:
     for line in lines:
         prefix = '\\subsection*{'
         postfix = '}\\label{pub-date}'
-        # \subsection*{21 January 2026}\label{pub-date}
         if line.startswith(prefix) and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
             debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
@@ -261,7 +260,6 @@ def main(args: list[str]) -> int:
 
         prefix = 'Hagen, and Thomas Schmidt. '
         postfix = '. OASIS Committee Specification'
-        # Hagen, and Thomas Schmidt. 21 January 2026. OASIS Committee Specification
         if line.startswith(prefix) and line.endswith(postfix):
             pub_date = line.replace(prefix, '').replace(postfix, '')
             debug and print(f'DEBUG: Found prior pub-date ({pub_date})')
@@ -279,7 +277,6 @@ def main(args: list[str]) -> int:
     bumped = []
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
-        #     footer_outer_field_normal_pages: 21 January 2026 - \theMetaPageNumPrefix { } \thepage { } of \pageref{LastPage}
         prefix = '    footer_outer_field_normal_pages: '
         postfix = ' - \\theMetaPageNumPrefix { } \\thepage { } of \\pageref{LastPage}'
         if line.startswith(prefix) and line.endswith(postfix):
@@ -301,7 +298,6 @@ def main(args: list[str]) -> int:
     for line in lines:
         prefix = '  \\cfoot*{\\upshape{\\scriptsize Copyright © OASIS Open '
         postfix = '. All Rights Reserved.}}'
-        #   \cfoot*{\upshape{\scriptsize Copyright © OASIS Open 2026. All Rights Reserved.}}
         if line.startswith(prefix) and line.endswith(postfix):
             copyright_year = line.replace(prefix, '').replace(postfix, '')
             debug and print(f'DEBUG: Found prior copyright-year ({copyright_year})')
@@ -319,7 +315,6 @@ def main(args: list[str]) -> int:
     bumped = []
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
-        # ## 21 January 2026
         prefix = '## '
         postfix = ''
         if line.startswith(prefix):
@@ -334,7 +329,6 @@ def main(args: list[str]) -> int:
             except ValueError:
                 pass
 
-        # 21 January 2026.
         prefix = ''
         postfix = '.'
         if 11 < len(line) < 19 and line.endswith(postfix):
@@ -349,7 +343,6 @@ def main(args: list[str]) -> int:
             debug and print(f'DEBUG: Bumped to ({job[PUB_DATE]})')
             continue
 
-        # Copyright &copy; OASIS Open 2026. All Rights Reserved.
         prefix = 'Copyright &copy; OASIS Open '
         postfix = '. All Rights Reserved.'
         if line.startswith(prefix) and line.endswith(postfix):
@@ -376,7 +369,6 @@ def main(args: list[str]) -> int:
     postfix = ' | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |'
     debug and print('#  -  -  -  -  -  -  -  -  - ')
     for line in lines:
-        # | eox-core-v1.0-wd20260121-dev | 2026-01-21 | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |
         # <-- append here when past_table is True
         if line.startswith(trigger_prefix) and past_table is None:
             past_table = False


### PR DESCRIPTION
This change-set closes #170 when merged to main.

# Tool Changes

- [x] Ensure the bump tool still works with the changed outline
- [x] Refactored obtaining the month names
- [x] Separate general parsing of parameters from date-spec parsing
- [x] Implement date-spec parsing as a testable library-level function
- [x] Migrate to data-oriented design by creating a transform function that receives the detection and transform tasks as data (3/5 transforms completed - out-of-time)
- [x] Enhance DX/UX by assessing the logging output for the known use cases

@camaleon2016 ... mention to keep you in the loop, Jay.
