### PR TITLE
Simplified revision history section for core and api

### DIFF
--- a/eox-api-v-1-0/prose/edit/src/revision-history.md
+++ b/eox-api-v-1-0/prose/edit/src/revision-history.md
@@ -8,8 +8,7 @@ toc:
 -->
 # Revision History
 
-| Revision                    | Date       | Editor                                         | Changes Made                      |
-|:----------------------------|:-----------|:-----------------------------------------------|:----------------------------------|
-| eox-api-v1.0-wd20250716-dev | 2025-07-16 | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |
+Revision tracking is publicly available in the version control system at
+<https://github.com/oasis-tcs/openeox/commits/main>.
 
--------
+---

--- a/eox-shell-v-1-0/prose/edit/src/revision-history.md
+++ b/eox-shell-v-1-0/prose/edit/src/revision-history.md
@@ -8,8 +8,7 @@ toc:
 -->
 # Revision History
 
-| Revision                      | Date       | Editor                                         | Changes Made                      |
-|:------------------------------|:-----------|:-----------------------------------------------|:----------------------------------|
-| eox-shell-v1.0-wd20250716-dev | 2025-07-16 | Jautau White, Stefan Hagen, and Thomas Schmidt | Editor Revision for TC review     |
+Revision tracking is publicly available in the version control system at
+<https://github.com/oasis-tcs/openeox/commits/main>.
 
--------
+---


### PR DESCRIPTION
Recent OASIS standards offer diverse statements and pointers to a revision history via GitHub links.

I went ahead and implemented my proposal from another TC https://github.com/oasis-tcs/csaf/issues/1421#issuecomment-4338819456 also for core and api as well as adapted to the different repository and branch.

I also reduced the funny horizontal line indicator to only three dashes because that is what came out of publication of another TC's CSD at https://docs.oasis-open.org/dps/prov-meta/v1.0/csd01/prov-meta-v1.0-csd01.md